### PR TITLE
78 better logging safer anki card object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ out/
 package-lock.json
 *.py~
 *.ts~
+test.py

--- a/GameSentenceMiner/anki.py
+++ b/GameSentenceMiner/anki.py
@@ -215,7 +215,10 @@ def check_for_new_cards():
         return
     new_card_ids = current_note_ids - previous_note_ids
     if new_card_ids and not first_run:
-        update_new_card()
+        try:
+            update_new_card()
+        except Exception as e:
+            logger.error("Error updating new card, Reason:", e)
     first_run = False
     previous_note_ids = current_note_ids  # Update the list of known notes
 

--- a/GameSentenceMiner/anki.py
+++ b/GameSentenceMiner/anki.py
@@ -12,8 +12,10 @@ from GameSentenceMiner import obs, util, notification, ffmpeg, gametext
 from GameSentenceMiner.configuration import *
 from GameSentenceMiner.configuration import get_config
 from GameSentenceMiner.gametext import get_text_event
+from GameSentenceMiner.model import AnkiCard
+from GameSentenceMiner.utility_gui import utility_window, get_utility_window
 from GameSentenceMiner.obs import get_current_game
-from GameSentenceMiner.util import remove_html_tags
+from GameSentenceMiner.util import remove_html_and_cloze_tags
 
 audio_in_anki = None
 screenshot_in_anki = None
@@ -25,15 +27,13 @@ first_run = True
 card_queue = []
 
 
-def update_anki_card(last_note, note=None, audio_path='', video_path='', tango='', reuse_audio=False,
+def update_anki_card(last_note: AnkiCard, note=None, audio_path='', video_path='', tango='', reuse_audio=False,
                      should_update_audio=True, ss_time=0, game_line=None):
     global audio_in_anki, screenshot_in_anki, prev_screenshot_in_anki
     update_audio = should_update_audio and (get_config().anki.sentence_audio_field and not
-    last_note['fields'][get_config().anki.sentence_audio_field][
-        'value'] or get_config().anki.overwrite_audio)
+    last_note.get_field(get_config().anki.sentence_audio_field) or get_config().anki.overwrite_audio)
     update_picture = (get_config().anki.picture_field and get_config().anki.overwrite_picture) or not \
-    last_note['fields'][get_config().anki.picture_field][
-        'value']
+    last_note.get_field(get_config().anki.picture_field)
 
     if not reuse_audio:
         if update_audio:
@@ -52,7 +52,7 @@ def update_anki_card(last_note, note=None, audio_path='', video_path='', tango='
     image_html = f"<img src=\"{screenshot_in_anki}\">"
     prev_screenshot_html = f"<img src=\"{prev_screenshot_in_anki}\">"
 
-    # note = {'id': last_note['noteId'], 'fields': {}}
+    # note = {'id': last_note.noteId, 'fields': {}}
 
     if update_audio:
         note['fields'][get_config().anki.sentence_audio_field] = audio_html
@@ -75,12 +75,12 @@ def update_anki_card(last_note, note=None, audio_path='', video_path='', tango='
         tags.append(get_current_game().replace(" ", ""))
     if tags:
         tag_string = " ".join(tags)
-        invoke("addTags", tags=tag_string, notes=[last_note['noteId']])
-    logger.info(f"UPDATED ANKI CARD FOR {last_note['noteId']}")
+        invoke("addTags", tags=tag_string, notes=[last_note.noteId])
+    logger.info(f"UPDATED ANKI CARD FOR {last_note.noteId}")
     if get_config().features.notify_on_update:
         notification.send_notification(tango)
     if get_config().features.open_anki_edit:
-        notification.open_anki_card(last_note['noteId'])
+        notification.open_anki_card(last_note.noteId)
 
     if get_config().audio.external_tool:
         open_audio_in_external(f"{get_config().audio.anki_media_collection}/{audio_in_anki}")
@@ -94,10 +94,9 @@ def open_audio_in_external(fileabspath, shell=False):
         subprocess.Popen([get_config().audio.external_tool, fileabspath])
 
 
-def add_image_to_card(last_note, image_path):
+def add_image_to_card(last_note: AnkiCard, image_path):
     global screenshot_in_anki
-    update_picture = get_config().anki.overwrite_picture or not last_note['fields'][get_config().anki.picture_field][
-        'value']
+    update_picture = get_config().anki.overwrite_picture or not last_note.get_field(get_config().anki.picture_field)
 
     if update_picture:
         screenshot_in_anki = store_media_file(image_path)
@@ -106,34 +105,37 @@ def add_image_to_card(last_note, image_path):
 
     image_html = f"<img src=\"{screenshot_in_anki}\">"
 
-    note = {'id': last_note['noteId'], 'fields': {}}
+    note = {'id': last_note.noteId, 'fields': {}}
 
     if update_picture:
         note['fields'][get_config().anki.picture_field] = image_html
 
     invoke("updateNoteFields", note=note)
 
-    logger.info(f"UPDATED IMAGE FOR ANKI CARD {last_note['noteId']}")
+    logger.info(f"UPDATED IMAGE FOR ANKI CARD {last_note.noteId}")
 
 
-def get_initial_card_info(last_note, selected_lines):
-    note = {'id': last_note['noteId'], 'fields': {}}
+def get_initial_card_info(last_note: AnkiCard, selected_lines):
+    note = {'id': last_note.noteId, 'fields': {}}
     if not last_note:
         return note
     game_line = get_text_event(last_note)
 
-    if get_config().audio.mining_from_history_grab_all_audio and get_config().anki.multi_overwrites_sentence:
-        lines = gametext.get_line_and_future_lines(last_note)
-        if lines:
-            note['fields'][get_config().anki.sentence_field] = "".join(lines)
-
     if selected_lines and get_config().anki.multi_overwrites_sentence:
-        note['fields'][get_config().anki.sentence_field] = "".join([line.text for line in selected_lines])
+        sentences = "".join([line.text for line in selected_lines])
+        try:
+            sentence_in_anki = last_note.get_field(get_config().anki.sentence_field)
+            logger.info(f"Attempting Preserve HTML for multi-line: {remove_html_and_cloze_tags(sentence_in_anki)}, {sentences}, {remove_html_and_cloze_tags(sentence_in_anki) in sentences}")
+            sentences = sentences.replace(remove_html_and_cloze_tags(sentence_in_anki), sentence_in_anki)
+        except Exception as e:
+            logger.debug(f"Error preserving HTML for multi-line: {e}")
+            pass
+        note['fields'][get_config().anki.sentence_field] = sentences
 
     if get_config().anki.previous_sentence_field and game_line.prev and not \
-            last_note['fields'][get_config().anki.previous_sentence_field]['value']:
+            last_note.get_field(get_config().anki.previous_sentence_field):
         logger.debug(
-            f"Adding Previous Sentence: {get_config().anki.previous_sentence_field and game_line.prev.text and not last_note['fields'][get_config().anki.previous_sentence_field]['value']}")
+            f"Adding Previous Sentence: {get_config().anki.previous_sentence_field and game_line.prev.text and not last_note.get_field(get_config().anki.previous_sentence_field)}")
         note['fields'][get_config().anki.previous_sentence_field] = game_line.prev.text
     return note
 
@@ -168,11 +170,11 @@ def invoke(action, **params):
     return response['result']
 
 
-def get_last_anki_card():
+def get_last_anki_card() -> AnkiCard | dict:
     added_ids = invoke('findNotes', query='added:1')
     if not added_ids:
         return {}
-    last_note = invoke('notesInfo', notes=[added_ids[-1]])[0]
+    last_note = AnkiCard.from_dict(invoke('notesInfo', notes=[added_ids[-1]])[0])
     return last_note
 
 
@@ -220,7 +222,7 @@ def check_for_new_cards():
 
 def update_new_card():
     last_card = get_last_anki_card()
-    if not check_tags_for_should_update(last_card):
+    if not last_card or not check_tags_for_should_update(last_card):
         return
     use_prev_audio = sentence_is_same_as_previous(last_card)
     logger.info(f"last mined line: {util.get_last_mined_line()}, current sentence: {get_sentence(last_card)}")
@@ -229,7 +231,7 @@ def update_new_card():
         obs.update_current_game()
     if use_prev_audio:
         with util.lock:
-            update_anki_card(last_card, note=get_initial_card_info(last_card, []), reuse_audio=True)
+            update_anki_card(last_card, note=get_initial_card_info(last_card, get_utility_window().get_selected_lines()), reuse_audio=True)
     else:
         logger.info("New card(s) detected! Added to Processing Queue!")
         card_queue.append(last_card)
@@ -239,20 +241,20 @@ def update_new_card():
 def sentence_is_same_as_previous(last_card):
     if not util.get_last_mined_line():
         return False
-    return remove_html_tags(get_sentence(last_card)) == remove_html_tags(util.get_last_mined_line())
+    return remove_html_and_cloze_tags(get_sentence(last_card)) == remove_html_and_cloze_tags(util.get_last_mined_line())
 
 def get_sentence(card):
-    return card['fields'][get_config().anki.sentence_field]['value']
+    return card.get_field(get_config().anki.sentence_field)
 
 def check_tags_for_should_update(last_card):
     if get_config().anki.tags_to_check:
         found = False
-        for tag in last_card['tags']:
+        for tag in last_card.tags:
             if tag.lower() in get_config().anki.tags_to_check:
                 found = True
                 break
         if not found:
-            logger.info(f"Card not tagged properly! Not updating! Note Tags: {last_card['tags']}, Tags_To_Check {get_config().anki.tags_to_check}")
+            logger.info(f"Card not tagged properly! Not updating! Note Tags: {last_card.tags}, Tags_To_Check {get_config().anki.tags_to_check}")
         return found
     else:
         return True

--- a/GameSentenceMiner/config_gui.py
+++ b/GameSentenceMiner/config_gui.py
@@ -6,6 +6,7 @@ import ttkbootstrap as ttk
 
 from GameSentenceMiner import obs, configuration
 from GameSentenceMiner.configuration import *
+from GameSentenceMiner.downloader.download_tools import download_ocenaudio_if_needed
 from GameSentenceMiner.electron_messaging import signal_restart_settings_change
 from GameSentenceMiner.package import get_current_version, get_latest_version
 
@@ -106,6 +107,7 @@ class ConfigApp:
                 use_clipboard=self.clipboard_enabled.get(),
                 websocket_uri=self.websocket_uri.get(),
                 open_config_on_startup=self.open_config_on_startup.get(),
+                open_multimine_on_startup=self.open_multimine_on_startup.get(),
                 texthook_replacement_regex=self.texthook_replacement_regex.get()
             ),
             paths=Paths(
@@ -160,7 +162,6 @@ class ConfigApp:
                 ffmpeg_reencode_options=self.ffmpeg_reencode_options.get(),
                 external_tool = self.external_tool.get(),
                 anki_media_collection=self.anki_media_collection.get(),
-                mining_from_history_grab_all_audio=self.mining_from_history_grab_all_audio.get()
             ),
             obs=OBS(
                 enabled=self.obs_enabled.get(),
@@ -184,7 +185,9 @@ class ConfigApp:
                 vosk_url='https://alphacephei.com/vosk/models/vosk-model-ja-0.22.zip' if self.vosk_url.get() == VOSK_BASE else "https://alphacephei.com/vosk/models/vosk-model-small-ja-0.22.zip",
                 selected_vad_model=self.selected_vad_model.get(),
                 backup_vad_model=self.backup_vad_model.get(),
-                trim_beginning=self.vad_trim_beginning.get()
+                trim_beginning=self.vad_trim_beginning.get(),
+                beginning_offset=float(self.vad_beginning_offset.get()),
+                add_audio_on_no_results=self.add_audio_on_no_results.get(),
             )
         )
 
@@ -296,6 +299,13 @@ class ConfigApp:
         self.add_label_and_increment_row(general_frame, "Whether to open config when the script starts.",
                                          row=self.current_row, column=2)
 
+        ttk.Label(general_frame, text="Open Multimine on Startup:").grid(row=self.current_row, column=0, sticky='W')
+        self.open_multimine_on_startup = tk.BooleanVar(value=self.settings.general.open_multimine_on_startup)
+        ttk.Checkbutton(general_frame, variable=self.open_multimine_on_startup).grid(row=self.current_row, column=1,
+                                                                                  sticky='W')
+        self.add_label_and_increment_row(general_frame, "Whether to open multimining window when the script starts.",
+                                         row=self.current_row, column=2)
+
         ttk.Label(general_frame, text="Current Version:").grid(row=self.current_row, column=0, sticky='W')
         self.current_version = ttk.Label(general_frame, text=get_current_version())
         self.current_version.grid(row=self.current_row, column=1)
@@ -364,6 +374,17 @@ class ConfigApp:
         ttk.Checkbutton(vad_frame, variable=self.vad_trim_beginning).grid(row=self.current_row, column=1, sticky='W')
         self.add_label_and_increment_row(vad_frame, "Trim the beginning of the audio based on Voice Detection Results",
                                          row=self.current_row, column=2)
+
+        ttk.Label(vad_frame, text="Beginning Offset After Beginning Trim:").grid(row=self.current_row, column=0, sticky='W')
+        self.vad_beginning_offset = ttk.Entry(vad_frame)
+        self.vad_beginning_offset.insert(0, str(self.settings.vad.beginning_offset))
+        self.vad_beginning_offset.grid(row=self.current_row, column=1)
+        self.add_label_and_increment_row(vad_frame, 'Beginning offset after VAD Trim, Only active if "Trim Beginning" is ON. Negative values = more time at the beginning', row=self.current_row, column=2)
+
+        ttk.Label(vad_frame, text="Add Audio on No Results:").grid(row=self.current_row, column=0, sticky='W')
+        self.add_audio_on_no_results = tk.BooleanVar(value=self.settings.vad.add_audio_on_no_results)
+        ttk.Checkbutton(vad_frame, variable=self.add_audio_on_no_results).grid(row=self.current_row, column=1, sticky='W')
+        self.add_label_and_increment_row(vad_frame, "Add audio even if no results are found by VAD.", row=self.current_row, column=2)
 
 
     @new_tab
@@ -740,12 +761,14 @@ class ConfigApp:
                                          row=self.current_row,
                                          column=2)
 
-        ttk.Label(audio_frame, text="Grab all Future Audio when Mining from History:").grid(row=self.current_row, column=0, sticky='W')
-        self.mining_from_history_grab_all_audio = tk.BooleanVar(
-            value=self.settings.audio.mining_from_history_grab_all_audio)
-        ttk.Checkbutton(audio_frame, variable=self.mining_from_history_grab_all_audio).grid(row=self.current_row, column=1, sticky='W')
-        self.add_label_and_increment_row(audio_frame, "When mining from History, this option will allow the script to get all audio from that line to the current time.", row=self.current_row,
-                                         column=2)
+        ttk.Button(audio_frame, text="Install Ocenaudio", command=self.download_and_install_ocen).grid(
+            row=self.current_row, column=0, pady=5)
+        ttk.Button(audio_frame, text="Get Anki Media Collection",
+                   command=self.set_default_anki_media_collection).grid(row=self.current_row, column=1, pady=5)
+        self.add_label_and_increment_row(audio_frame,
+                                         "These Two buttons both help set up the External Audio Editing Tool. The first one downloads and installs OcenAudio, a free audio editing software. The second one sets the default Anki media collection path.",
+                                         row=self.current_row,
+                                         column=3)
 
     @new_tab
     def create_obs_tab(self):
@@ -897,6 +920,24 @@ class ConfigApp:
 
     def show_error_box(self, title, message):
         messagebox.showerror(title, message)
+
+    def download_and_install_ocen(self):
+        confirm = messagebox.askyesno("Download OcenAudio?", "Would you like to download and install OcenAudio? It is a free audio editing software that works extremely well with GSM.")
+        if confirm:
+            exe_path = download_ocenaudio_if_needed()
+            messagebox.showinfo("OcenAudio Downloaded", f"OcenAudio has been downloaded and installed. You can find it at {exe_path}.")
+            self.external_tool.delete(0, tk.END)
+            self.external_tool.insert(0, exe_path)
+            self.save_settings()
+
+    def set_default_anki_media_collection(self):
+        confirm = messagebox.askyesno("Set Default Anki Media Collection?", "Would you like to set the default Anki media collection path? This will help the script find the media collection for external trimming.\n\nDefault: %APPDATA%/Anki2/User 1/collection.media")
+        if confirm:
+            default_path = get_default_anki_media_collection_path()
+            if default_path != self.settings.audio.external_tool:
+                self.anki_media_collection.delete(0, tk.END)
+                self.anki_media_collection.insert(0, default_path)
+                self.save_settings()
 
 
 if __name__ == '__main__':

--- a/GameSentenceMiner/config_gui.py
+++ b/GameSentenceMiner/config_gui.py
@@ -86,6 +86,7 @@ class ConfigApp:
         on_save.append(func)
 
     def show(self):
+        logger.info("Showing Configuration Window")
         obs.update_current_game()
         self.reload_settings()
         if self.window is not None:
@@ -218,6 +219,7 @@ class ConfigApp:
             signal_restart_settings_change()
         settings_saved = True
         configuration.reload_config()
+        self.settings = get_config()
         for func in on_save:
             func()
 
@@ -228,8 +230,9 @@ class ConfigApp:
 
         self.window.title("GameSentenceMiner Configuration - " + current_config.name)
 
-        if current_config.name != self.settings.name:
-            logger.info("Profile changed, reloading settings.")
+
+        if current_config.name != self.settings.name or self.settings.config_changed(current_config):
+            logger.info("Config changed, reloading settings.")
             self.master_config = new_config
             self.settings = current_config
             for frame in self.notebook.winfo_children():

--- a/GameSentenceMiner/configuration.py
+++ b/GameSentenceMiner/configuration.py
@@ -246,8 +246,12 @@ class ProfileConfig:
                 previous.obs.host != self.obs.host,
                 previous.obs.port != self.obs.port
                 ]):
+            logger.info("Restart Required for Some Settings that were Changed")
             return True
         return False
+
+    def config_changed(self, new: 'ProfileConfig') -> bool:
+        return self != new
 
 
 @dataclass_json
@@ -390,14 +394,19 @@ def reload_config():
 def get_master_config():
     return config_instance
 
-def save_config(config):
+def save_full_config(config):
     with open(get_config_path(), 'w') as file:
         json.dump(config.to_dict(), file, indent=4)
+
+def save_current_config(config):
+    global config_instance
+    config_instance.set_config_for_profile(config_instance.current_profile, config)
+    save_full_config(config_instance)
 
 def switch_profile_and_save(profile_name):
     global config_instance
     config_instance.current_profile = profile_name
-    save_config(config_instance)
+    save_full_config(config_instance)
     return config_instance.get_config()
 
 

--- a/GameSentenceMiner/configuration.py
+++ b/GameSentenceMiner/configuration.py
@@ -42,6 +42,7 @@ class General:
     use_clipboard: bool = True
     websocket_uri: str = 'localhost:6677'
     open_config_on_startup: bool = False
+    open_multimine_on_startup: bool = False
     texthook_replacement_regex: str = ""
 
 
@@ -116,7 +117,6 @@ class Audio:
     ffmpeg_reencode_options: str = ''
     external_tool: str = ""
     anki_media_collection: str = ""
-    mining_from_history_grab_all_audio: bool = False
 
 
 @dataclass_json
@@ -150,6 +150,8 @@ class VAD:
     selected_vad_model: str = SILERO
     backup_vad_model: str = OFF
     trim_beginning: bool = False
+    beginning_offset: float = -0.5
+    add_audio_on_no_results: bool = False
 
 
 @dataclass_json
@@ -276,6 +278,17 @@ class Config:
         return self.configs[DEFAULT_CONFIG]
 
 
+def get_default_anki_path():
+    if platform == 'win32':  # Windows
+        base_dir = os.getenv('APPDATA')
+    else:  # macOS and Linux
+        base_dir = '~/.local/share/'
+    config_dir = os.path.join(base_dir, 'Anki2')
+    return config_dir
+
+def get_default_anki_media_collection_path():
+    return os.path.join(get_default_anki_path(), 'User 1', 'collection.media')
+
 def get_app_directory():
     if platform == 'win32':  # Windows
         appdata_dir = os.getenv('APPDATA')
@@ -377,11 +390,14 @@ def reload_config():
 def get_master_config():
     return config_instance
 
+def save_config(config):
+    with open(get_config_path(), 'w') as file:
+        json.dump(config.to_dict(), file, indent=4)
+
 def switch_profile_and_save(profile_name):
     global config_instance
     config_instance.current_profile = profile_name
-    with open(get_config_path(), 'w') as file:
-        json.dump(config_instance.to_dict(), file, indent=4)
+    save_config(config_instance)
     return config_instance.get_config()
 
 

--- a/GameSentenceMiner/downloader/download_tools.py
+++ b/GameSentenceMiner/downloader/download_tools.py
@@ -149,10 +149,39 @@ def download_ffmpeg_if_needed():
                 with source, target:
                     shutil.copyfileobj(source, target)
     logger.info(f"FFmpeg extracted to {ffmpeg_dir}.")
+
+def download_ocenaudio_if_needed():
+    ocenaudio_dir = os.path.join(get_app_directory(), 'ocenaudio', 'ocenaudio')
+    ocenaudio_exe_path = os.path.join(ocenaudio_dir, 'ocenaudio.exe')
+    if os.path.exists(ocenaudio_dir) and os.path.exists(ocenaudio_exe_path):
+        logger.info(f"Ocenaudio already installed at {ocenaudio_dir}.")
+        return ocenaudio_exe_path
+
+    if os.path.exists(ocenaudio_dir) and not os.path.exists(ocenaudio_exe_path):
+        logger.info("Ocenaudio directory exists but executable is missing. Re-downloading Ocenaudio...")
+        shutil.rmtree(ocenaudio_dir)
+
+    ocenaudio_url = "https://www.ocenaudio.com/downloads/ocenaudio_windows64.zip"
+
+    download_dir = os.path.join(get_app_directory(), "downloads")
+    os.makedirs(download_dir, exist_ok=True)
+    ocenaudio_archive = os.path.join(download_dir, "ocenaudio.zip")
+
+    logger.info(f"Downloading Ocenaudio from {ocenaudio_url}...")
+    urllib.request.urlretrieve(ocenaudio_url, ocenaudio_archive)
+    logger.info(f"Ocenaudio downloaded. Extracting to {ocenaudio_dir}...")
+
+    os.makedirs(ocenaudio_dir, exist_ok=True)
+    with zipfile.ZipFile(ocenaudio_archive, 'r') as zip_ref:
+        zip_ref.extractall(ocenaudio_dir)
+
+    logger.info(f"Ocenaudio extracted to {ocenaudio_dir}.")
+    return ocenaudio_exe_path
+
 def main():
-    # Run dependency checks
     download_obs_if_needed()
     download_ffmpeg_if_needed()
+    download_ocenaudio_if_needed()
 
 if __name__ == "__main__":
     main()

--- a/GameSentenceMiner/ffmpeg.py
+++ b/GameSentenceMiner/ffmpeg.py
@@ -200,7 +200,7 @@ def trim_audio_based_on_last_line(untrimmed_audio, video_path, game_line, next_l
     ffmpeg_command = ffmpeg_base_command_list + [
         "-i", untrimmed_audio,
         "-ss", start_trim_time]
-    if next_line and next_line > game_line.time and not get_config().audio.mining_from_history_grab_all_audio:
+    if next_line and next_line > game_line.time:
         end_total_seconds = total_seconds + (next_line - game_line.time).total_seconds() + 1
         hours, remainder = divmod(end_total_seconds, 3600)
         minutes, seconds = divmod(remainder, 60)

--- a/GameSentenceMiner/ffmpeg.py
+++ b/GameSentenceMiner/ffmpeg.py
@@ -290,12 +290,14 @@ def convert_audio_to_wav(input_audio, output_wav):
 def trim_audio(input_audio, start_time, end_time, output_audio):
     command = ffmpeg_base_command_list.copy()
 
+    command.extend(['-i', input_audio])
+
     if get_config().vad.trim_beginning and start_time > 0:
+        logger.info(f"trimming beginning to {start_time}")
         command.extend(['-ss', f"{start_time:.2f}"])
 
     command.extend([
         '-to', f"{end_time:.2f}",
-        '-i', input_audio,
         '-c', 'copy',
         output_audio
     ])

--- a/GameSentenceMiner/gsm.py
+++ b/GameSentenceMiner/gsm.py
@@ -337,11 +337,13 @@ def switch_profile(icon, item):
         logger.error("You cannot switch to the currently active profile!")
         return
     logger.info(f"Switching to profile: {item.text}")
+    prev_config = get_config()
     get_master_config().current_profile = item.text
     switch_profile_and_save(item.text)
     settings_window.reload_settings()
     update_icon()
-    signal_restart_settings_change()
+    if get_config().restart_required(prev_config):
+        signal_restart_settings_change()
 
 
 def run_tray():

--- a/GameSentenceMiner/model.py
+++ b/GameSentenceMiner/model.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 
 from dataclasses_json import dataclass_json
 
-from GameSentenceMiner.configuration import get_config, logger, save_config
+from GameSentenceMiner.configuration import get_config, logger, save_current_config
 
 
 # OBS
@@ -95,9 +95,10 @@ class AnkiCard:
     mod: int
     cards: list[int]
     alternatives = {
-        "word_field": ["Front", "Word", "TargetWord"],
-        "sentence_field": ["Example", "Context", "Back"],
-        "picture_field": ["Image", "Visual", "Media"]
+        "word_field": ["Front", "Word", "TargetWord", "Expression"],
+        "sentence_field": ["Example", "Context", "Back", "Sentence"],
+        "picture_field": ["Image", "Visual", "Media", "Picture", "Screenshot", 'AnswerImage'],
+        "sentence_audio_field": ["SentenceAudio"]
     }
 
     def get_field(self, field_name: str) -> str:
@@ -115,32 +116,41 @@ class AnkiCard:
         if not self.has_field(config.anki.word_field):
             found_alternative_field, field = self.find_field(config.anki.word_field, "word_field")
             if found_alternative_field:
-                logger.warning(f"Saving alternative field '{field}' for word_field to settings.")
+                logger.warning(f"{config.anki.word_field} Not found in Anki Card! Saving alternative field '{field}' for word_field to settings.")
                 config.anki.word_field = field
                 changes_found = True
 
         if not self.has_field(config.anki.sentence_field):
             found_alternative_field, field = self.find_field(config.anki.sentence_field, "sentence_field")
             if found_alternative_field:
-                logger.warning(f"Saving alternative field '{field}' for sentence_field to settings.")
+                logger.warning(f"{config.anki.sentence_field} Not found in Anki Card! Saving alternative field '{field}' for sentence_field to settings.")
                 config.anki.sentence_field = field
                 changes_found = True
 
         if not self.has_field(config.anki.picture_field):
             found_alternative_field, field = self.find_field(config.anki.picture_field, "picture_field")
             if found_alternative_field:
-                logger.warning(f"Saving alternative field '{field}' for picture_field to settings.")
+                logger.warning(f"{config.anki.picture_field} Not found in Anki Card! Saving alternative field '{field}' for picture_field to settings.")
                 config.anki.picture_field = field
                 changes_found = True
+
+        if not self.has_field(config.anki.sentence_audio_field):
+            found_alternative_field, field = self.find_field(config.anki.sentence_audio_field, "sentence_audio_field")
+            if found_alternative_field:
+                logger.warning(f"{config.anki.sentence_audio_field} Not found in Anki Card! Saving alternative field '{field}' for sentence_audio_field to settings.")
+                config.anki.sentence_audio_field = field
+                changes_found = True
+
         if changes_found:
-            save_config(config)
+            save_current_config(config)
 
     def find_field(self, field, field_type):
         if field in self.fields:
             return False, field
 
         for alt_field in self.alternatives[field_type]:
-            if alt_field in self.fields:
-                return True, alt_field
+            for key in self.fields:
+                if alt_field.lower() == key.lower():
+                    return True, key
 
         return False, None

--- a/GameSentenceMiner/model.py
+++ b/GameSentenceMiner/model.py
@@ -3,6 +3,8 @@ from typing import Optional, List
 
 from dataclasses_json import dataclass_json
 
+from GameSentenceMiner.configuration import get_config, logger, save_config
+
 
 # OBS
 @dataclass_json
@@ -82,3 +84,63 @@ class SceneItemsResponse:
 #     videoActive: bool
 #     videoShowing: bool
 
+@dataclass_json
+@dataclass
+class AnkiCard:
+    noteId: int
+    profile: str
+    tags: list[str]
+    fields: dict[str, dict[str, str]]
+    modelName: str
+    mod: int
+    cards: list[int]
+    alternatives = {
+        "word_field": ["Front", "Word", "TargetWord"],
+        "sentence_field": ["Example", "Context", "Back"],
+        "picture_field": ["Image", "Visual", "Media"]
+    }
+
+    def get_field(self, field_name: str) -> str:
+        if self.has_field(field_name):
+            return self.fields[field_name]['value']
+        else:
+            raise ValueError(f"Field '{field_name}' not found in AnkiCard. Please make sure your Anki Field Settings in GSM Match your fields in your Anki Note!")
+
+    def has_field (self, field_name: str) -> bool:
+        return field_name in self.fields
+
+    def __post_init__(self):
+        config = get_config()
+        changes_found = False
+        if not self.has_field(config.anki.word_field):
+            found_alternative_field, field = self.find_field(config.anki.word_field, "word_field")
+            if found_alternative_field:
+                logger.warning(f"Saving alternative field '{field}' for word_field to settings.")
+                config.anki.word_field = field
+                changes_found = True
+
+        if not self.has_field(config.anki.sentence_field):
+            found_alternative_field, field = self.find_field(config.anki.sentence_field, "sentence_field")
+            if found_alternative_field:
+                logger.warning(f"Saving alternative field '{field}' for sentence_field to settings.")
+                config.anki.sentence_field = field
+                changes_found = True
+
+        if not self.has_field(config.anki.picture_field):
+            found_alternative_field, field = self.find_field(config.anki.picture_field, "picture_field")
+            if found_alternative_field:
+                logger.warning(f"Saving alternative field '{field}' for picture_field to settings.")
+                config.anki.picture_field = field
+                changes_found = True
+        if changes_found:
+            save_config(config)
+
+    def find_field(self, field, field_type):
+        if field in self.fields:
+            return False, field
+
+        for alt_field in self.alternatives[field_type]:
+            if alt_field in self.fields:
+                return True, alt_field
+
+        return False, None

--- a/GameSentenceMiner/notification.py
+++ b/GameSentenceMiner/notification.py
@@ -69,3 +69,12 @@ def send_check_obs_notification(reason):
         app_name="GameSentenceMiner",
         timeout=5  # Notification disappears after 5 seconds
     )
+
+
+def send_error_no_anki_update():
+    notification.notify(
+        title="Error",
+        message=f"Anki Card not updated, Check Console for Reason!",
+        app_name="GameSentenceMiner",
+        timeout=5  # Notification disappears after 5 seconds
+    )

--- a/GameSentenceMiner/util.py
+++ b/GameSentenceMiner/util.py
@@ -143,6 +143,6 @@ def is_windows():
 #     else:
 #         return subprocess.run(command, shell=shell, input=input, capture_output=capture_output, timeout=timeout,
 #                               check=check, **kwargs)
-def remove_html_tags(text):
-    clean_text = re.sub(r'<.*?>', '', text)
-    return clean_text
+def remove_html_and_cloze_tags(text):
+    text = re.sub(r'<.*?>', '', re.sub(r'{{c\d+::(.*?)(::.*?)?}}', r'\1', text))
+    return text

--- a/GameSentenceMiner/utility_gui.py
+++ b/GameSentenceMiner/utility_gui.py
@@ -3,7 +3,6 @@ from tkinter import ttk
 
 from GameSentenceMiner.configuration import logger
 
-
 class UtilityApp:
     def __init__(self, root):
         self.root = root
@@ -120,6 +119,16 @@ class UtilityApp:
         # if self.multi_mine_window:
         #     for checkbox in self.checkboxes:
         #         checkbox.set(False)
+
+def init_utility_window(root):
+    global utility_window
+    utility_window = UtilityApp(root)
+    return utility_window
+
+def get_utility_window():
+    return utility_window
+
+utility_window: UtilityApp = None
 
 
 if __name__ == "__main__":

--- a/GameSentenceMiner/vad/silero_trim.py
+++ b/GameSentenceMiner/vad/silero_trim.py
@@ -38,6 +38,6 @@ def process_audio_with_silero(input_audio, output_audio):
     end_time = voice_activity[-1]['end'] if voice_activity else 0
 
     # Trim the audio using FFmpeg
-    ffmpeg.trim_audio(input_audio, start_time, end_time + get_config().audio.end_offset, output_audio)
+    ffmpeg.trim_audio(input_audio, start_time + get_config().vad.beginning_offset, end_time + get_config().audio.end_offset, output_audio)
     logger.info(f"Trimmed audio saved to: {output_audio}")
     return True

--- a/GameSentenceMiner/vad/vosk_helper.py
+++ b/GameSentenceMiner/vad/vosk_helper.py
@@ -140,7 +140,7 @@ def process_audio_with_vosk(input_audio, output_audio):
     logger.info(f"Trimmed End of Audio to {end_time} seconds:")
 
     # Trim the audio using FFmpeg
-    ffmpeg.trim_audio(input_audio, start_time, end_time + get_config().audio.end_offset, output_audio)
+    ffmpeg.trim_audio(input_audio, start_time + get_config().vad.beginning_offset, end_time + get_config().audio.end_offset, output_audio)
     logger.info(f"Trimmed audio saved to: {output_audio}")
     return True
 

--- a/GameSentenceMiner/vad/whisper_helper.py
+++ b/GameSentenceMiner/vad/whisper_helper.py
@@ -87,7 +87,7 @@ def process_audio_with_whisper(input_audio, output_audio):
     logger.info(f"Trimmed End of Audio to {end_time} seconds:")
 
     # Trim the audio using FFmpeg
-    ffmpeg.trim_audio(input_audio, start_time, end_time + get_config().audio.end_offset, output_audio)
+    ffmpeg.trim_audio(input_audio, start_time + get_config().vad.beginning_offset, end_time + get_config().audio.end_offset, output_audio)
     logger.info(f"Trimmed audio saved to: {output_audio}")
     return True
 

--- a/electron-src/main/main.ts
+++ b/electron-src/main/main.ts
@@ -256,7 +256,7 @@ function openYuzuWindow() {
 
 async function updateGSM() {
     isUpdating = true;
-    checkForUpdates(pythonPath).then(async ({updateAvailable, latestVersion}) => {
+    checkForUpdates().then(async ({updateAvailable, latestVersion}) => {
         if (updateAvailable) {
             console.log("Update available. Closing GSM...");
             closeGSM();
@@ -329,14 +329,14 @@ app.whenReady().then(() => {
     if (!isDev && getAutoUpdateElectron()) {
         autoUpdate()
     }
-    if (getAutoUpdateGSMApp()) {
-        updateGSM();
-    }
     createWindow();
     createTray();
     getOrInstallPython().then((path: string) => {
         pythonPath = path;
         setPythonPath(pythonPath);
+        if (getAutoUpdateGSMApp()) {
+            updateGSM();
+        }
         ensureAndRunGSM(pythonPath).then(() => {
             if (!isUpdating) {
                 quit();

--- a/electron-src/main/update_checker.ts
+++ b/electron-src/main/update_checker.ts
@@ -1,13 +1,14 @@
 import { execSync } from "child_process";
 import axios from "axios";
 import log from "electron-log";
+import {getPythonPath} from "./store.js";
 
 const PACKAGE_NAME = "GameSentenceMiner";
 
 // Get current installed version using `pip show`
-function getCurrentVersion(pythonPath: string): string | null {
+function getCurrentVersion(): string | null {
     try {
-        const output = execSync(`${pythonPath} -m pip show ${PACKAGE_NAME}`, { encoding: "utf-8" });
+        const output = execSync(`${getPythonPath()} -m pip show ${PACKAGE_NAME}`, { encoding: "utf-8" });
         console.log(output);
         const versionMatch = output.match(/Version: ([\d.]+)/);
         return versionMatch ? versionMatch[1] : null;
@@ -29,9 +30,9 @@ async function getLatestVersion(): Promise<string | null> {
 }
 
 // Check for updates
-async function checkForUpdates(pythonPath: string, force: boolean = false): Promise<{ updateAvailable: boolean; latestVersion: string | null }> {
+async function checkForUpdates(force: boolean = false): Promise<{ updateAvailable: boolean; latestVersion: string | null }> {
     try {
-        const installedVersion = getCurrentVersion(pythonPath);
+        const installedVersion = getCurrentVersion();
         const latestVersion = await getLatestVersion();
 
         console.log(`Installed version: ${installedVersion}`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GameSentenceMiner"
-version = "2.5.0.dev1"
+version = "2.5.0"
 description = "A tool for mining sentences from games. Update: Multi-Line Mining! Fixed!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GameSentenceMiner"
-version = "2.4.12"
+version = "2.5.0.dev1"
 description = "A tool for mining sentences from games. Update: Multi-Line Mining! Fixed!"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Preserve HTML/Cloze Tags in Anki when multi-mining and replacing Sentence is **enabled.**
- Backend Anki Card Object changes, shouldn't change any logic, just makes the Anki card easier to work with in Python
- Verify Anki Fields and Try alternatives, if no alternatives found, print useful error instead of the stacktrace
- Config to open Multi-line window when GSM starts
- Button for Install Ocen Audio + Select Anki Default Media Directory for "Open in External Program"
- Option to add Audio even when no voice is found
- Option for beginning offset for the VAD result (aka start of voice + beginning offset, negative = more time before voice starts)
- Removed "Get all future audio when mining from history" option
- Updated the `remove_html_tags` logic when finding the sentence in history to also remove cloze tags, this will not reflect in your anki card, it will just make finding the sentence you are actually mining more reliable
- Made some errors give more information than just printing the stacktrace (i.e. when there are no lines recieved)
- Added notification when it errors to check the console/debug for more info.
- Errors are now red in the electron console log (not sure what caused this actually)