### PR TITLE
when unlinking or linking to jiten, rerun stats rollup

### DIFF
--- a/GameSentenceMiner/web/jiten_database_api.py
+++ b/GameSentenceMiner/web/jiten_database_api.py
@@ -355,6 +355,14 @@ def register_jiten_database_api_routes(app):
 
             logger.info(f"Linked game {game_id} to jiten.moe deck {deck_id}")
 
+            # Trigger stats rollup after linking game
+            try:
+                logger.info("Triggering stats rollup after game link")
+                run_daily_rollup()
+            except Exception as rollup_error:
+                logger.error(f"Stats rollup failed after game link: {rollup_error}")
+                # Don't fail the link operation if rollup fails
+
             return jsonify(
                 {
                     "success": True,


### PR DESCRIPTION
this is bc the name used in the rollup changes depending on whether its linked or not
this increases time it takes to link / unlink something, but stops unexpected behaviour when rollup doesnt run and the name doesnt change :)