### PR TITLE
get_ids: return line IDs in insertion order

### DIFF
--- a/GameSentenceMiner/web/events.py
+++ b/GameSentenceMiner/web/events.py
@@ -33,13 +33,11 @@ class EventItem:
 
 
 class EventManager:
-    ids: set[str] = set()
     events: list[EventItem]
     events_dict: dict[str, EventItem] = {}
 
     def __init__(self):
         self.events = []
-        self.ids = set()
         self.timed_out_ids = set()
         self.events_dict = {}
 
@@ -49,13 +47,11 @@ class EventManager:
     def replace_events(self, new_events: list[EventItem]):
         self.events = new_events
         self.events_dict = {event.id: event for event in new_events}
-        self.ids = {event.id for event in new_events}
 
     def add_gameline(self, line: GameLine):
         new_event = EventItem(line, line.id, line.text,
                               line.time, False, False)
         self.events_dict[line.id] = new_event
-        self.ids.add(line.id)
         self.events.append(new_event)
         return new_event
 
@@ -68,13 +64,13 @@ class EventManager:
 
     def add_event(self, event):
         self.events.append(event)
-        self.ids.add(event.id)
+        self.events_dict[event.id] = event
 
     def get(self, event_id):
         return self.events_dict.get(event_id)
 
-    def get_ids(self):
-        return self.ids
+    def get_ordered_ids(self):
+        return list(self.events_dict)
 
     def clear_history(self):
         # Clear the in-memory events
@@ -82,7 +78,6 @@ class EventManager:
             event for event in self.events if not event.history]
         self.events_dict = {
             event.id: event for event in self.events}
-        self.ids = {event.id for event in self.events}
 
     def remove_lines_by_ids(self, ids: list[str], timed_out: bool = False):
         ids_to_remove = set(ids)
@@ -92,8 +87,6 @@ class EventManager:
         for event_id in ids_to_remove:
             self.events_dict.pop(event_id, None)
         
-        # Remove from set (much more efficient than rebuilding)
-        self.ids -= ids_to_remove
         if timed_out:
             self.timed_out_ids.update(ids_to_remove)
 

--- a/GameSentenceMiner/web/texthooking_page.py
+++ b/GameSentenceMiner/web/texthooking_page.py
@@ -204,7 +204,7 @@ def get_ids():
     asyncio.run(check_for_lines_outside_replay_buffer())
     return jsonify(
         {
-            "ids": list(event_manager.get_ids()),
+            "ids": event_manager.get_ordered_ids(),
             "timed_out_ids": list(event_manager.timed_out_ids),
         }
     )


### PR DESCRIPTION
| Prior to this change | This PR |
| --- | --- |
| <img width="1918" height="2036" src="https://github.com/user-attachments/assets/90145465-2379-4061-9217-938a2d18f183" /> | <img width="1918" height="2036" src="https://github.com/user-attachments/assets/76a782b9-f76f-4898-b960-683d4488dc32" /> |

The "translate multiple" feature is supposed to translate the N last lines on demand, but the `/get_ids` endpoint was backed by a Python `set`, which is an [unordered collection](https://docs.python.org/3.14/library/stdtypes.html#set-types-set-frozenset). This meant the last-N-lines JS logic was effectively picking the lines to translate at random.
This PR modifies the `/get_ids` endpoint to build the list of IDs based on a Python dictionary instead, which is guaranteed to preserve insertion order starting with Python 3.7:
> Changed in version 3.7: Dictionary order is guaranteed to be insertion order. This behavior was an implementation detail of CPython from 3.6. [[source]](https://docs.python.org/3.14/library/stdtypes.html#dict)

Note: Python 3.7 has been end-of-life since 2023-06-27.

Additionally, this PR removes the `EventManager.ids` property, as it is no longer needed for anything.