### PR TITLE
Standardize Menubar UI and make macOS display the correct app icon

### DIFF
--- a/electron-src/main/main.ts
+++ b/electron-src/main/main.ts
@@ -698,7 +698,7 @@ async function createWindow() {
 
     mainWindow.loadFile(path.join(getAssetsDir(), 'index.html'));
 
-    const menu = Menu.buildFromTemplate([
+    const template: Electron.MenuItemConstructorOptions[] = [
         {
             label: 'File',
             submenu: [
@@ -733,7 +733,33 @@ async function createWindow() {
                 },
             ],
         },
-    ]);
+    ];
+
+    if (process.platform === 'darwin') {
+        const fileMenu = template.find((item) => item.label === 'File');
+        if (fileMenu && Array.isArray(fileMenu.submenu)) {
+            // Remove Quit from File menu on macOS
+            fileMenu.submenu = fileMenu.submenu.filter((item: any) => item.label !== 'Quit');
+        }
+
+        template.unshift({
+            label: APP_NAME,
+            submenu: [
+                { role: 'about' },
+                { type: 'separator' },
+                { role: 'services' },
+                { type: 'separator' },
+                { role: 'hide' },
+                { role: 'hideOthers' },
+                { role: 'unhide' },
+                { type: 'separator' },
+                { label: 'Quit', click: async () => await quit() },
+            ],
+        });
+    }
+
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
 
     if (isDev) {
         menu.append(
@@ -746,6 +772,8 @@ async function createWindow() {
                 },
             })
         );
+        // Re-set application menu after append
+        Menu.setApplicationMenu(menu);
     }
 
     mainWindow.setMenu(menu);
@@ -1027,6 +1055,12 @@ async function processArgsAndStartSettings() {
 }
 
 app.setPath('userData', path.join(BASE_DIR, 'electron'));
+
+// Fix for name and icon on macOS
+if (process.platform === 'darwin') {
+    app.setName(APP_NAME);
+    app.dock?.setIcon(getIconPath());
+}
 
 if (!app.requestSingleInstanceLock()) {
     app.whenReady().then(() => {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       "artifactName": "${productName}-Setup-${version}.${ext}"
     },
     "mac": {
-      "target": "dmg"
+      "target": "dmg",
+      "icon": "assets/gsm.png"
     },
     "linux": {
       "target": "AppImage"


### PR DESCRIPTION
This pr makes macOS actually display the defualt icon, before it was just a generic electron icon.
Before: 
<img width="396" height="408" alt="image-2026-01-14-154305" src="https://github.com/user-attachments/assets/85db6153-ce7c-4119-b362-480499ec8ec1" />
<img width="1506" height="1262" alt="image-2026-01-14-154257" src="https://github.com/user-attachments/assets/79f052b9-2a89-4ba6-8ade-9af0b03775c9" />
After:
<img width="392" height="418" alt="image-2026-01-14-154355" src="https://github.com/user-attachments/assets/335036a4-99d6-485d-b40f-d9255560c316" />
<img width="1490" height="1256" alt="image-2026-01-14-154334" src="https://github.com/user-attachments/assets/d648bc1b-418a-4fb8-a1f7-7c83962db0ef" />
Also, the menubar at the top is now in line with the one on Windows, making it more consistent across both platforms.
Before:

https://github.com/user-attachments/assets/75136360-17f5-4011-a086-df4b9489f38e

After:

https://github.com/user-attachments/assets/ff65b4f9-f3cf-4718-a64c-6a9d276e682e


The "Electron" label seen in "After" is a side-effect of macOS identifying the app by its development process (running via npm). This should be resolved in the packaged version, where the application correctly identifies as GameSentenceMiner.