### PR TITLE
Update voice detection to Title Case

### DIFF
--- a/GameSentenceMiner/locales/en_us.json
+++ b/GameSentenceMiner/locales/en_us.json
@@ -272,7 +272,7 @@
           }
         },
         "vad": {
-          "title": "voice detection",
+          "title": "Voice Detection",
           "do_postprocessing": {
             "label": "Voice Detection Postprocessing:",
             "tooltip": "Enable post-processing of audio to trim just the voiceline."
@@ -672,13 +672,11 @@
           "periodic_interval": {
             "label": "Capture Interval (Seconds):",
             "tooltip": "Interval in seconds for periodic screen capture."
-          }
-          ,
+          },
           "periodic_ratio": {
             "label": "Periodic Match Ratio:",
             "tooltip": "Ratio (0-1) used during periodic scanning to determine how much of the region must match to count as detected. Higher = Less Strict, more Scanning."
-          }
-          ,
+          },
           "number_of_local_scans_per_event": {
             "label": "Local Scans Per Text Event:",
             "tooltip": "How many local scans to perform per text event (agent, textractor, etc.) before stopping or sending results to the OCR engine. .1s delay between scans for now."


### PR DESCRIPTION
I noticed in the settings popup that "Voice Detection" was all lowercase instead of Title Case:

<img width="800" height="268" alt="image" src="https://github.com/user-attachments/assets/7a1eb354-6450-40e7-a606-82c62b648a4f" />

So this updates it to be Title Case like the other settings headers I saw.

This matches what the default is if there is no string, so guessing it was just a typo in the i18n file:

https://github.com/bpwhelan/GameSentenceMiner/blob/7c6de21c8ae0c4a97baa5a1f2cfc0ee263ae6eda/GameSentenceMiner/ui/config_gui_qt.py#L1616

My editor also automatically formatted a couple of commas that were on standalone lines to move them to the previous line, but that seemed appropriate given typical JSON formatting. I can update to remove that bit if desired.