### PR TITLE
support for controller prev/next entry navigation

### DIFF
--- a/GSM_Overlay/gamepad.js
+++ b/GSM_Overlay/gamepad.js
@@ -44,6 +44,8 @@ class GamepadHandler {
       forwardEnterButton: options.forwardEnterButton ?? -1, // Disabled by default; forwards Enter to target game window
       manualOverlayScanButton: options.manualOverlayScanButton ?? -1, // Disabled by default; triggers manual overlay scan
       tokenModeToggleButton: options.tokenModeToggleButton ?? 3, // Y button to toggle token/char mode
+      nextEntryButton: options.nextEntryButton ?? 7, // RT trigger - navigate to next Yomitan entry
+      prevEntryButton: options.prevEntryButton ?? 6, // LT trigger - navigate to previous Yomitan entry
       
       // D-Pad buttons
       dpadUp: 12,
@@ -1725,6 +1727,18 @@ class GamepadHandler {
       return;
     }
     
+    // Handle Yomitan entry navigation (popup must be visible)
+    if (this.yomitanPopupVisible) {
+      if (this.config.nextEntryButton >= 0 && buttonIndex === this.config.nextEntryButton) {
+        this.navigateYomitanNextEntry();
+        return;
+      }
+      if (this.config.prevEntryButton >= 0 && buttonIndex === this.config.prevEntryButton) {
+        this.navigateYomitanPrevEntry();
+        return;
+      }
+    }
+    
     // Handle confirm/cancel buttons
     if (this.isNavigationActive()) {
       if (buttonIndex === this.config.confirmButton) {
@@ -2081,6 +2095,16 @@ class GamepadHandler {
     }
     this.sendYomitanControlMessage('confirm-action');
     return true;
+  }
+
+  navigateYomitanNextEntry() {
+    if (!this.yomitanPopupVisible) return;
+    this.sendYomitanControlMessage('next-entry');
+  }
+
+  navigateYomitanPrevEntry() {
+    if (!this.yomitanPopupVisible) return;
+    this.sendYomitanControlMessage('previous-entry');
   }
   
   // ==================== Navigation Logic ====================

--- a/GSM_Overlay/index.html
+++ b/GSM_Overlay/index.html
@@ -2909,6 +2909,8 @@ function clearTextBoxes() {
     cancelButton: 1, // B
     forwardEnterButton: -1, // Disabled
     manualOverlayScanButton: -1, // Disabled
+    nextEntryButton: 7, // RT trigger - navigate to next Yomitan entry
+    prevEntryButton: 6, // LT trigger - navigate to previous Yomitan entry
     repeatDelay: 400,
     repeatRate: 150,
     autoConfirmSelection: true,
@@ -2950,6 +2952,8 @@ function clearTextBoxes() {
       cancelButton: gamepadSettings.cancelButton,
       forwardEnterButton: gamepadSettings.forwardEnterButton,
       manualOverlayScanButton: gamepadSettings.manualOverlayScanButton,
+      nextEntryButton: gamepadSettings.nextEntryButton,
+      prevEntryButton: gamepadSettings.prevEntryButton,
       repeatDelay: gamepadSettings.repeatDelay,
       repeatRate: gamepadSettings.repeatRate,
       autoConfirmSelection: gamepadSettings.autoConfirmSelection,

--- a/GSM_Overlay/main.js
+++ b/GSM_Overlay/main.js
@@ -168,6 +168,8 @@ let userSettings = {
   "gamepadCancelButton": 1, // B
   "gamepadForwardEnterButton": -1, // Disabled by default; forwards Enter to target game window
   "gamepadManualOverlayScanButton": -1, // Disabled by default; triggers manual overlay scan
+  "gamepadNextEntryButton": 7, // RT trigger - navigate to next Yomitan entry
+  "gamepadPrevEntryButton": 6, // LT trigger - navigate to previous Yomitan entry
   "gamepadAutoConfirmSelection": true,
   "gamepadRepeatDelay": 400,
   "gamepadRepeatRate": 150,
@@ -3224,6 +3226,8 @@ app.whenReady().then(async () => {
       case "gamepadCancelButton":
       case "gamepadForwardEnterButton":
       case "gamepadManualOverlayScanButton":
+      case "gamepadNextEntryButton":
+      case "gamepadPrevEntryButton":
       case "gamepadAutoConfirmSelection":
       case "gamepadRepeatDelay":
       case "gamepadRepeatRate":

--- a/GSM_Overlay/yomitan/js/display/display-anki.js
+++ b/GSM_Overlay/yomitan/js/display/display-anki.js
@@ -265,8 +265,32 @@ export class DisplayAnki {
                 this._cancelGsmActionSelectionRetry();
                 this._clearGsmActionSelection();
                 break;
+            case 'next-entry':
+                this._navigateGsmNextEntry();
+                break;
+            case 'previous-entry':
+                this._navigateGsmPreviousEntry();
+                break;
             default:
                 break;
+        }
+    }
+
+    /**
+     * Navigate to next entry (gamepad/controller command)
+     */
+    _navigateGsmNextEntry() {
+        if (this._display) {
+            this._display._focusEntry(this._display.selectedIndex + 1, 0, true);
+        }
+    }
+
+    /**
+     * Navigate to previous entry (gamepad/controller command)
+     */
+    _navigateGsmPreviousEntry() {
+        if (this._display) {
+            this._display._focusEntry(Math.max(0, this._display.selectedIndex - 1), 0, true);
         }
     }
 


### PR DESCRIPTION
Hi, I used copilot to try to make the feature I was talking about on discord :)
It didn't need to change a lot for it to work. and I could build and test it easily. 
It adds support to be able to switch from one entry to another in the yomitan popup using the trigger buttons of the controller to be able to mine words after the first entry.
like the yomitan keyboard shortcut "go to next/previous entry".

https://github.com/user-attachments/assets/9ed7b0c6-7cc4-40d5-9de7-a1834c7add68

