### PR TITLE
Improve furigana placement and expose furigana style controls

### DIFF
--- a/GSM_Overlay/index.html
+++ b/GSM_Overlay/index.html
@@ -93,6 +93,16 @@ background: rgba(202, 12, 12, 0.692);
       2px 0 0 #222,
       0 -2px 0 #222,
       0 2px 0 #222;
+    line-height: 1;
+    overflow: visible;
+  }
+
+  .furigana-piece {
+    position: absolute;
+    top: 0;
+    white-space: nowrap;
+    text-align: center;
+    transform: translateX(-50%);
   }
 
   .text-box-container {
@@ -1060,6 +1070,10 @@ background: rgba(202, 12, 12, 0.692);
   let showTextIndicators = true;
   let fadeTextIndicators = false;
   let showFurigana = false;
+  let furiganaScale = 0.5;
+  let furiganaFontFamily = '';
+  let furiganaColor = '#ffffff';
+  let furiganaYOffset = 0;
   let showRecycledIndicator = true;
   let overlayRenderGeneration = 0;
   let display = null;
@@ -2007,6 +2021,76 @@ background: rgba(202, 12, 12, 0.692);
     return characters;
   }
 
+  function isKanaCharacter(char) {
+    return typeof char === 'string' && /[ぁ-ゖァ-ヺー]/.test(char);
+  }
+
+  function isKanjiCharacter(char) {
+    return typeof char === 'string' && /[\u3400-\u4dbf\u4e00-\u9fff々〆ヵヶ]/.test(char);
+  }
+
+  function mapReadingToKanjiSlots(word, reading) {
+    if (typeof word !== 'string' || typeof reading !== 'string' || !word || !reading) {
+      return [];
+    }
+
+    let wordStart = 0;
+    let readingStart = 0;
+    while (
+      wordStart < word.length &&
+      readingStart < reading.length &&
+      word[wordStart] === reading[readingStart] &&
+      isKanaCharacter(word[wordStart])
+    ) {
+      wordStart += 1;
+      readingStart += 1;
+    }
+
+    let wordEnd = word.length;
+    let readingEnd = reading.length;
+    while (
+      wordEnd > wordStart &&
+      readingEnd > readingStart &&
+      word[wordEnd - 1] === reading[readingEnd - 1] &&
+      isKanaCharacter(word[wordEnd - 1])
+    ) {
+      wordEnd -= 1;
+      readingEnd -= 1;
+    }
+
+    const kanjiOffsets = [];
+    for (let i = wordStart; i < wordEnd; i += 1) {
+      if (isKanjiCharacter(word[i])) {
+        kanjiOffsets.push(i);
+      }
+    }
+
+    const readingCore = reading.slice(readingStart, readingEnd) || reading;
+    if (kanjiOffsets.length === 0 || !readingCore) {
+      return [{ startOffset: 0, endOffset: word.length, reading: readingCore || reading }];
+    }
+
+    const pieces = [];
+    const totalChars = readingCore.length;
+    for (let i = 0; i < kanjiOffsets.length; i += 1) {
+      const start = Math.floor((i * totalChars) / kanjiOffsets.length);
+      const end = Math.floor(((i + 1) * totalChars) / kanjiOffsets.length);
+      const part = readingCore.slice(start, end);
+      if (!part) {
+        continue;
+      }
+      pieces.push({
+        startOffset: kanjiOffsets[i],
+        endOffset: kanjiOffsets[i] + 1,
+        reading: part,
+      });
+    }
+
+    return pieces.length > 0
+      ? pieces
+      : [{ startOffset: wordStart, endOffset: wordEnd, reading: readingCore }];
+  }
+
   function createFuriganaBoxesForLine(line, segments) {
     const boxes = [];
     const characters = buildLineCharacterBoxes(line);
@@ -2031,20 +2115,46 @@ background: rgba(202, 12, 12, 0.692);
         continue;
       }
 
-      const furiganaBox = document.createElement('ruby');
+      const furiganaBox = document.createElement('div');
       furiganaBox.className = 'furigana-box';
-
-      const rtElement = document.createElement('rt');
-      rtElement.textContent = segment.reading;
-      furiganaBox.appendChild(rtElement);
 
       const segmentWidth = Math.max(0.2, endChar.x3 - startChar.x1);
       const charHeightPx = ((startChar.y3 - startChar.y1) / 100) * window.innerHeight;
       const baseFontSize = Math.max(8, Math.min(100, Math.round(charHeightPx)));
-      const furiganaFontSize = baseFontSize * 0.5;
+      const furiganaFontSize = Math.max(8, baseFontSize * furiganaScale);
       const furiganaHeight = furiganaFontSize * 1.1;
       const furiganaHeightPercent = (furiganaHeight / window.innerHeight) * 100;
-      const furiganaTop = startChar.y1 - furiganaHeightPercent;
+      const furiganaTop = startChar.y1 - furiganaHeightPercent + furiganaYOffset;
+
+      const segmentText = typeof segment.text === 'string' && segment.text.length > 0
+        ? segment.text
+        : characters.slice(start, end).map((charInfo) => charInfo.text).join('');
+      const readingPieces = mapReadingToKanjiSlots(segmentText, segment.reading);
+      const piecesToRender = readingPieces.length > 0
+        ? readingPieces
+        : [{ startOffset: 0, endOffset: Math.max(1, end - start), reading: segment.reading }];
+
+      for (const piece of piecesToRender) {
+        const pieceStartIndex = Math.max(start, Math.min(end - 1, start + Number(piece.startOffset || 0)));
+        const pieceEndIndex = Math.max(pieceStartIndex + 1, Math.min(end, start + Number(piece.endOffset || 1)));
+        const pieceStartChar = characters[pieceStartIndex];
+        const pieceEndChar = characters[pieceEndIndex - 1];
+        if (!pieceStartChar || !pieceEndChar || !piece.reading) {
+          continue;
+        }
+
+        const pieceElement = document.createElement('span');
+        pieceElement.className = 'furigana-piece';
+        pieceElement.textContent = piece.reading;
+        pieceElement.style.left = `${((pieceStartChar.x1 + pieceEndChar.x3) / 2) - startChar.x1}%`;
+        pieceElement.style.width = `${Math.max(0.2, pieceEndChar.x3 - pieceStartChar.x1)}%`;
+        pieceElement.style.fontSize = `${furiganaFontSize}px`;
+        furiganaBox.appendChild(pieceElement);
+      }
+
+      if (furiganaBox.childElementCount === 0) {
+        continue;
+      }
 
       furiganaBox.style.position = 'absolute';
       furiganaBox.style.whiteSpace = 'nowrap';
@@ -2058,7 +2168,8 @@ background: rgba(202, 12, 12, 0.692);
       furiganaBox.style.lineHeight = '1';
       furiganaBox.style.display = (furiganaVisible && !(manualMode && !manualHotkeyPressed)) ? 'block' : 'none';
       furiganaBox.style.fontSize = `${furiganaFontSize}px`;
-      rtElement.style.fontSize = `${furiganaFontSize}px`;
+      furiganaBox.style.fontFamily = furiganaFontFamily || 'inherit';
+      furiganaBox.style.color = furiganaColor || '#ffffff';
       furiganaBox.style.left = `${startChar.x1 + offsetX}%`;
       furiganaBox.style.top = `${furiganaTop + offsetY}%`;
       furiganaBox.style.textAlign = 'left';
@@ -2313,6 +2424,10 @@ function clearTextBoxes() {
     shouldShowReadyIndicator = newsettings.showReadyIndicator !== false;
     showFurigana = newsettings.showFurigana;
     hideFuriganaOnStartup = newsettings.hideFuriganaOnStartup === true;
+    furiganaScale = Number.isFinite(Number(newsettings.furiganaScale)) ? Number(newsettings.furiganaScale) : 0.5;
+    furiganaFontFamily = typeof newsettings.furiganaFontFamily === 'string' ? newsettings.furiganaFontFamily : '';
+    furiganaColor = typeof newsettings.furiganaColor === 'string' ? newsettings.furiganaColor : '#ffffff';
+    furiganaYOffset = Number.isFinite(Number(newsettings.furiganaYOffset)) ? Number(newsettings.furiganaYOffset) : 0;
     if (newsettings.hideYomitanAfterMine !== undefined) {
       hideYomitanAfterMine = newsettings.hideYomitanAfterMine;
     }
@@ -2497,6 +2612,18 @@ function clearTextBoxes() {
           break;
         case "hideFuriganaOnStartup":
           hideFuriganaOnStartup = value;
+          break;
+        case "furiganaScale":
+          furiganaScale = Number.isFinite(Number(value)) ? Number(value) : furiganaScale;
+          break;
+        case "furiganaFontFamily":
+          furiganaFontFamily = typeof value === 'string' ? value : furiganaFontFamily;
+          break;
+        case "furiganaColor":
+          furiganaColor = typeof value === 'string' ? value : furiganaColor;
+          break;
+        case "furiganaYOffset":
+          furiganaYOffset = Number.isFinite(Number(value)) ? Number(value) : furiganaYOffset;
           break;
         case "hideYomitanAfterMine":
           hideYomitanAfterMine = value;

--- a/GSM_Overlay/main.js
+++ b/GSM_Overlay/main.js
@@ -151,6 +151,10 @@ let userSettings = {
   "afkTimer": 5, // in minutes
   "showFurigana": false,
   "hideFuriganaOnStartup": false,
+  "furiganaScale": 0.5,
+  "furiganaFontFamily": "",
+  "furiganaColor": "#ffffff",
+  "furiganaYOffset": 0,
   "hideYomitanAfterMine": false,
   "offsetX": 0,
   "offsetY": 0,

--- a/GSM_Overlay/settings.html
+++ b/GSM_Overlay/settings.html
@@ -680,6 +680,22 @@
         <span class="label-text">Hide Furigana on Startup (Toggle with hotkey to show)</span>
         <input type="checkbox" id="hideFuriganaOnStartup" />
       </label>
+      <label class="sub-option">
+        <span class="label-text">Furigana Size Scale</span>
+        <input type="number" id="furiganaScale" value="0.5" step="0.05" min="0.2" max="1.5" />
+      </label>
+      <label class="sub-option">
+        <span class="label-text">Furigana Font Family (optional)</span>
+        <input type="text" id="furiganaFontFamily" value="" placeholder="inherit (same as overlay text)" />
+      </label>
+      <label class="sub-option">
+        <span class="label-text">Furigana Font Color</span>
+        <input type="color" id="furiganaColor" value="#ffffff" />
+      </label>
+      <label class="sub-option">
+        <span class="label-text">Furigana Vertical Offset (%)</span>
+        <input type="number" id="furiganaYOffset" value="0" step="0.1" min="-20" max="20" />
+      </label>
     </div>
 
     <div class="setting-group" data-tab="general">
@@ -1459,6 +1475,24 @@
       handleSettingChange("hideFuriganaOnStartup", event.target.checked);
     });
 
+    document.getElementById("furiganaScale").addEventListener("input", (event) => {
+      const value = parseFloat(event.target.value);
+      handleSettingChange("furiganaScale", Number.isFinite(value) ? value : 0.5);
+    });
+
+    document.getElementById("furiganaFontFamily").addEventListener("blur", (event) => {
+      handleSettingChange("furiganaFontFamily", event.target.value || "");
+    });
+
+    document.getElementById("furiganaColor").addEventListener("input", (event) => {
+      handleSettingChange("furiganaColor", event.target.value || "#ffffff");
+    });
+
+    document.getElementById("furiganaYOffset").addEventListener("input", (event) => {
+      const value = parseFloat(event.target.value);
+      handleSettingChange("furiganaYOffset", Number.isFinite(value) ? value : 0);
+    });
+
     document.getElementById("showRecycledIndicator").addEventListener("change", (event) => {
       handleSettingChange("showRecycledIndicator", event.target.checked);
     });
@@ -1998,6 +2032,7 @@
       const { 
         fontSize, weburl1, weburl2, hideOnStartup, manualMode, manualModeType, 
         showHotkey, pinned, showTextIndicators, fadeTextIndicators, afkTimer, showFurigana, hideFuriganaOnStartup,
+        furiganaScale, furiganaFontFamily, furiganaColor, furiganaYOffset,
         offsetX, offsetY, toggleFuriganaHotkey, translateHotkey, autoRequestTranslation,
         toggleWindowHotkey, minimizeHotkey, yomitanSettingsHotkey, overlaySettingsHotkey,
         texthookerHotkey, texthookerUrl
@@ -2027,6 +2062,10 @@
       document.getElementById("showReadyIndicator").checked = userSettings.showReadyIndicator;
       document.getElementById("showFurigana").checked = showFurigana;
       document.getElementById("hideFuriganaOnStartup").checked = hideFuriganaOnStartup === true;
+      document.getElementById("furiganaScale").value = Number.isFinite(Number(furiganaScale)) ? Number(furiganaScale) : 0.5;
+      document.getElementById("furiganaFontFamily").value = typeof furiganaFontFamily === 'string' ? furiganaFontFamily : '';
+      document.getElementById("furiganaColor").value = typeof furiganaColor === 'string' ? furiganaColor : '#ffffff';
+      document.getElementById("furiganaYOffset").value = Number.isFinite(Number(furiganaYOffset)) ? Number(furiganaYOffset) : 0;
       document.getElementById("showRecycledIndicator").checked = userSettings.showRecycledIndicator !== false;
       mainBoxStartupWarningAcknowledged = userSettings.mainBoxStartupWarningAcknowledged === true;
       if (document.getElementById("showMainBoxOnStartup").checked && !mainBoxStartupWarningAcknowledged) {


### PR DESCRIPTION
### Motivation
- Okurigana was sometimes included in the displayed furigana and long/multi-kanji readings were rendered as a single clumped label instead of being distributed across the kanji (examples like `離れ離れ` should have readings spread per-kanji). 
- Users need basic runtime tuning for furigana appearance (size, font, color, and optional vertical offset) to match different games and fonts.

### Description
- Reworked overlay furigana rendering in `GSM_Overlay/index.html` to compute character boxes, detect kanji vs kana, trim kana-prefix/suffix, and split a reading into per-kanji pieces via a new `mapReadingToKanjiSlots` helper so readings are centered above their target kanji spans instead of being lumped together. 
- Replaced the single `ruby` output with a positioned `div.furigana-box` and individual `span.furigana-piece` elements for each reading piece, added CSS adjustments (`.furigana-box`, `.furigana-piece`) and improved font/overflow/line-height handling to improve centering and visibility. 
- Exposed user-configurable furigana controls by adding UI fields in `GSM_Overlay/settings.html` (`furiganaScale`, `furiganaFontFamily`, `furiganaColor`, `furiganaYOffset`) and wired their change handlers to `setting-changed` events. 
- Added persisted defaults and wiring in `GSM_Overlay/main.js` (`furiganaScale`, `furiganaFontFamily`, `furiganaColor`, `furiganaYOffset`) and loaded/applied these values in the overlay renderer (`load-settings` / `settings-updated`).

### Testing
- Ran `git diff --check` which produced no whitespace/errors and succeeded. 
- Attempted `pytest` for `tests/util/config/test_overlay_config.py` but it failed in this environment because `pytest` is not available in the active `.venv` (no test run completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e255e634832e88f23ad9ab7aeb5c)