### PR TITLE
Use character dict for overlay furigana + controller

### DIFF
--- a/GSM_Overlay/input_server/mecab_bridge.py
+++ b/GSM_Overlay/input_server/mecab_bridge.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -81,29 +81,22 @@ except Exception as exc:
         flush=True,
     )
 
+get_recent_character_name_index = None
+merge_tokens_with_character_names = None
+tokens_to_furigana_segments = None
 
-def is_kanji(char: str) -> bool:
-    code = ord(char)
-    return (
-        0x4E00 <= code <= 0x9FFF
-        or 0x3400 <= code <= 0x4DBF
-        or 0x20000 <= code <= 0x2A6DF
+try:
+    from GameSentenceMiner.util.yomitan_dict.character_names import (
+        get_recent_character_name_index,
+        merge_tokens_with_character_names,
+        tokens_to_furigana_segments,
     )
-
-
-def has_kanji(text: str) -> bool:
-    return any(is_kanji(c) for c in text)
-
-
-def katakana_to_hiragana(text: str) -> str:
-    out: List[str] = []
-    for c in text:
-        code = ord(c)
-        if 0x30A1 <= code <= 0x30F6:
-            out.append(chr(code - 0x60))
-        else:
-            out.append(c)
-    return "".join(out)
+except Exception as exc:
+    print(
+        f"[mecab_bridge] Character-name helpers unavailable: {exc}",
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 def fallback_tokens(text: str) -> List[Dict[str, Any]]:
@@ -114,49 +107,132 @@ def fallback_tokens(text: str) -> List[Dict[str, Any]]:
     return tokens
 
 
-def tokenize_text(text: str) -> List[Dict[str, Any]]:
+def _text_contains_kanji(text: str) -> bool:
+    for char in text:
+        code = ord(char)
+        if (
+            0x4E00 <= code <= 0x9FFF
+            or 0x3400 <= code <= 0x4DBF
+            or 0x20000 <= code <= 0x2A6DF
+        ):
+            return True
+    return False
+
+
+def _katakana_to_hiragana(text: str) -> str:
+    out: List[str] = []
+    for char in text:
+        code = ord(char)
+        if 0x30A1 <= code <= 0x30F6:
+            out.append(chr(code - 0x60))
+        else:
+            out.append(char)
+    return "".join(out)
+
+
+def _tokens_to_furigana_segments_default(
+    tokens: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    segments: List[Dict[str, Any]] = []
+
+    for token in tokens:
+        word = str(token.get("word") or "")
+        start = token.get("start")
+        end = token.get("end")
+        if not word or not isinstance(start, int) or not isinstance(end, int):
+            continue
+
+        reading = str(token.get("reading") or "").strip()
+        reading_hiragana = _katakana_to_hiragana(reading) if reading else ""
+        has_reading = (
+            bool(reading_hiragana)
+            and reading_hiragana != word
+            and _text_contains_kanji(word)
+        )
+        segments.append(
+            {
+                "text": word,
+                "start": start,
+                "end": end,
+                "hasReading": has_reading,
+                "reading": reading_hiragana if has_reading else None,
+            }
+        )
+
+    return segments
+
+
+def _tokenize_via_mecab(text: str) -> List[Dict[str, Any]]:
     if mecab_controller is None:
         return fallback_tokens(text)
 
-    try:
-        parsed = mecab_controller.translate(text)
-        tokens: List[Dict[str, Any]] = []
-        position = 0
+    parsed = mecab_controller.translate(text)
+    tokens: List[Dict[str, Any]] = []
+    position = 0
 
-        for token in parsed:
-            word = token.word if hasattr(token, "word") else str(token)
-            word_len = len(word)
-            if not word:
-                continue
-            if word.isspace():
-                position += word_len
-                continue
-
-            token_data: Dict[str, Any] = {
-                "word": word,
-                "start": position,
-                "end": position + word_len,
-            }
-
-            reading = getattr(token, "katakana_reading", None)
-            if reading:
-                token_data["reading"] = reading
-
-            headword = getattr(token, "headword", None)
-            if headword:
-                token_data["headword"] = headword
-
-            pos = getattr(token, "part_of_speech", None)
-            if pos:
-                token_data["pos"] = str(pos)
-
-            tokens.append(token_data)
+    for token in parsed:
+        word = token.word if hasattr(token, "word") else str(token)
+        word_len = len(word)
+        if not word:
+            continue
+        if word.isspace():
             position += word_len
+            continue
 
+        token_data: Dict[str, Any] = {
+            "word": word,
+            "start": position,
+            "end": position + word_len,
+        }
+
+        reading = getattr(token, "katakana_reading", None)
+        if reading:
+            token_data["reading"] = reading
+
+        headword = getattr(token, "headword", None)
+        if headword:
+            token_data["headword"] = headword
+
+        pos = getattr(token, "part_of_speech", None)
+        if pos:
+            token_data["pos"] = str(pos)
+
+        tokens.append(token_data)
+        position += word_len
+
+    return tokens
+
+
+def _apply_character_name_overrides(
+    text: str,
+    tokens: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    if (
+        not text
+        or not tokens
+        or get_recent_character_name_index is None
+        or merge_tokens_with_character_names is None
+    ):
         return tokens
+
+    try:
+        name_index = get_recent_character_name_index()
+        return merge_tokens_with_character_names(text, tokens, name_index)
+    except Exception as exc:
+        print(
+            f"[mecab_bridge] character-name merge failed: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return tokens
+
+
+def tokenize_text(text: str) -> List[Dict[str, Any]]:
+    try:
+        return _apply_character_name_overrides(text, _tokenize_via_mecab(text))
     except Exception as exc:
         print(f"[mecab_bridge] tokenize failed: {exc}", file=sys.stderr, flush=True)
-        return fallback_tokens(text)
+        return _apply_character_name_overrides(text, fallback_tokens(text))
 
 
 def fallback_furigana(text: str) -> List[Dict[str, Any]]:
@@ -172,39 +248,9 @@ def fallback_furigana(text: str) -> List[Dict[str, Any]]:
 
 
 def get_furigana(text: str) -> List[Dict[str, Any]]:
-    if mecab_controller is None:
-        return fallback_furigana(text)
-
     try:
-        parsed = mecab_controller.translate(text)
-        segments: List[Dict[str, Any]] = []
-        position = 0
-
-        for token in parsed:
-            word = token.word if hasattr(token, "word") else str(token)
-            word_len = len(word)
-            if not word:
-                continue
-
-            segment: Dict[str, Any] = {
-                "text": word,
-                "start": position,
-                "end": position + word_len,
-                "hasReading": False,
-                "reading": None,
-            }
-
-            if has_kanji(word):
-                reading = getattr(token, "katakana_reading", None)
-                if reading:
-                    reading = katakana_to_hiragana(reading)
-                    if reading != word:
-                        segment["hasReading"] = True
-                        segment["reading"] = reading
-
-            segments.append(segment)
-            position += word_len
-
+        converter = tokens_to_furigana_segments or _tokens_to_furigana_segments_default
+        segments = converter(tokenize_text(text))
         return segments if segments else fallback_furigana(text)
     except Exception as exc:
         print(f"[mecab_bridge] furigana failed: {exc}", file=sys.stderr, flush=True)

--- a/GameSentenceMiner/util/yomitan_dict/character_names.py
+++ b/GameSentenceMiner/util/yomitan_dict/character_names.py
@@ -1,0 +1,439 @@
+"""Shared recent-character-name helpers for Yomitan and controller tokenization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+
+import jaconv
+
+from GameSentenceMiner.util.config.configuration import logger
+
+if TYPE_CHECKING:
+    from GameSentenceMiner.util.database.games_table import GamesTable
+
+
+RECENT_CHARACTER_GAME_COUNT = 3
+RECENT_CHARACTER_MAX_SEARCH = 50
+CHARACTER_NAME_CACHE_TTL_SECONDS = 60.0
+CHARACTER_CATEGORIES = ("main", "primary", "side", "appears")
+
+
+@dataclass(frozen=True)
+class CharacterNameCandidate:
+    """A searchable character-name variant with a canonical reading."""
+
+    term: str
+    reading_hiragana: str
+    reading_katakana: str
+    headword: str
+
+
+_NAME_PARSER = None
+_CACHED_NAME_INDEX: Optional[Dict[str, List[CharacterNameCandidate]]] = None
+_CACHED_NAME_INDEX_AT = 0.0
+
+
+def _get_games_table():
+    from GameSentenceMiner.util.database.games_table import GamesTable
+
+    return GamesTable
+
+
+def _get_name_parser():
+    global _NAME_PARSER
+    if _NAME_PARSER is None:
+        from .name_parser import NameParser
+
+        _NAME_PARSER = NameParser()
+    return _NAME_PARSER
+
+
+def has_character_data(game: "GamesTable") -> bool:
+    """Validate that a game has at least one character entry."""
+    if not game.vndb_character_data:
+        return False
+
+    try:
+        char_data = game.vndb_character_data
+        if isinstance(char_data, str):
+            char_data = json.loads(char_data)
+
+        if not isinstance(char_data, dict):
+            return False
+
+        characters_obj = char_data.get("characters", {})
+        if not isinstance(characters_obj, dict):
+            return False
+
+        for category in CHARACTER_CATEGORIES:
+            characters = characters_obj.get(category, [])
+            if isinstance(characters, list) and len(characters) > 0:
+                return True
+
+        return False
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return False
+
+
+def get_recent_games_with_character_data(
+    desired_count: int = RECENT_CHARACTER_GAME_COUNT,
+    max_search: int = RECENT_CHARACTER_MAX_SEARCH,
+) -> List[GamesTable]:
+    """Return recently played games that have usable character data."""
+    GamesTable = _get_games_table()
+    query = """
+        SELECT g.id
+        FROM games g
+        LEFT JOIN (
+            SELECT game_id, MAX(timestamp) AS last_played
+            FROM game_lines
+            WHERE game_id IS NOT NULL AND game_id != ''
+            GROUP BY game_id
+        ) gl ON g.id = gl.game_id
+        WHERE g.vndb_character_data IS NOT NULL
+          AND g.vndb_character_data != ''
+          AND g.vndb_character_data != '{}'
+        ORDER BY gl.last_played DESC NULLS LAST
+        LIMIT ?
+    """
+    rows = GamesTable._db.fetchall(query, (max_search,))
+
+    logger.info(
+        f"Character names: Found {len(rows)} games with populated vndb_character_data"
+    )
+
+    valid_games: List[GamesTable] = []
+    checked_games = []
+
+    for (game_id,) in rows:
+        game = GamesTable.get(game_id)
+        if not game:
+            continue
+
+        game_title = game.title_original or game.title_romaji or game.title_english or game_id
+        if has_character_data(game):
+            valid_games.append(game)
+            checked_games.append((game_title, True))
+            logger.info(f"Character names: + '{game_title}'")
+            if len(valid_games) >= desired_count:
+                break
+        else:
+            checked_games.append((game_title, False))
+            logger.info(f"Character names: - '{game_title}' (empty or invalid)")
+
+    if valid_games:
+        logger.info(
+            f"Character names: Using {len(valid_games)} game(s) out of {len(checked_games)} checked"
+        )
+    else:
+        logger.warning(
+            f"Character names: No recent games with valid character data found (checked {len(checked_games)})"
+        )
+
+    return valid_games
+
+
+def _iter_game_characters(game: "GamesTable"):
+    char_data = game.vndb_character_data
+    if char_data is None:
+        return
+
+    if isinstance(char_data, str):
+        try:
+            char_data = json.loads(char_data)
+        except json.JSONDecodeError:
+            return
+
+    if not isinstance(char_data, dict):
+        return
+
+    characters_obj = char_data.get("characters", {})
+    if not isinstance(characters_obj, dict):
+        return
+
+    for category in CHARACTER_CATEGORIES:
+        characters = characters_obj.get(category, [])
+        if not isinstance(characters, list):
+            continue
+        for char in characters:
+            if isinstance(char, dict):
+                yield char
+
+
+def build_character_name_candidates(char: Dict[str, Any]) -> List[CharacterNameCandidate]:
+    """Build the name variants and readings used for character-aware tokenization."""
+    name_original = char.get("name_original", "") or char.get("name", "")
+    if not name_original:
+        return []
+
+    name_parser = _get_name_parser()
+    romanized_name = char.get("name", "")
+    hiragana_readings = name_parser.generate_mixed_name_readings(name_original, romanized_name)
+    name_parts = name_parser.split_japanese_name(name_original)
+    canonical_headword = name_parts.get("combined") or name_parts.get("original") or name_original
+
+    candidates: List[CharacterNameCandidate] = []
+    added_terms = set()
+
+    def add_candidate(term: Optional[str], reading: Optional[str], headword: Optional[str] = None) -> None:
+        normalized_term = str(term or "").strip()
+        if not normalized_term or normalized_term in added_terms:
+            return
+
+        normalized_reading = str(reading or "").strip()
+        candidates.append(
+            CharacterNameCandidate(
+                term=normalized_term,
+                reading_hiragana=normalized_reading,
+                reading_katakana=jaconv.hira2kata(normalized_reading) if normalized_reading else "",
+                headword=str(headword or canonical_headword or normalized_term),
+            )
+        )
+        added_terms.add(normalized_term)
+
+    if name_parts["has_space"]:
+        add_candidate(name_parts.get("original"), hiragana_readings.get("full"))
+        add_candidate(name_parts.get("combined"), hiragana_readings.get("full"))
+        add_candidate(name_parts.get("family"), hiragana_readings.get("family"))
+        add_candidate(name_parts.get("given"), hiragana_readings.get("given"))
+    else:
+        add_candidate(name_original, hiragana_readings.get("full"))
+
+    base_names_with_readings = []
+    if name_parts["has_space"]:
+        if name_parts.get("family"):
+            base_names_with_readings.append((name_parts["family"], hiragana_readings.get("family")))
+        if name_parts.get("given"):
+            base_names_with_readings.append((name_parts["given"], hiragana_readings.get("given")))
+        if name_parts.get("combined"):
+            base_names_with_readings.append((name_parts["combined"], hiragana_readings.get("full")))
+        if name_parts.get("original"):
+            base_names_with_readings.append((name_parts["original"], hiragana_readings.get("full")))
+    else:
+        base_names_with_readings.append((name_original, hiragana_readings.get("full")))
+
+    for base_name, base_reading in base_names_with_readings:
+        for suffix, suffix_reading in name_parser.HONORIFIC_SUFFIXES:
+            add_candidate(
+                f"{base_name}{suffix}",
+                f"{base_reading or ''}{suffix_reading}",
+            )
+
+    aliases = char.get("aliases", [])
+    if isinstance(aliases, list):
+        for alias in aliases:
+            add_candidate(alias, hiragana_readings.get("full"))
+            for suffix, suffix_reading in name_parser.HONORIFIC_SUFFIXES:
+                add_candidate(
+                    f"{alias}{suffix}",
+                    f"{hiragana_readings.get('full') or ''}{suffix_reading}",
+                )
+
+    return candidates
+
+
+def build_recent_character_name_candidates(
+    desired_count: int = RECENT_CHARACTER_GAME_COUNT,
+    max_search: int = RECENT_CHARACTER_MAX_SEARCH,
+) -> List[CharacterNameCandidate]:
+    """Build searchable name variants from recent games, keeping most recent collisions."""
+    candidates: List[CharacterNameCandidate] = []
+    seen_terms = set()
+
+    for game in get_recent_games_with_character_data(desired_count=desired_count, max_search=max_search):
+        for char in _iter_game_characters(game):
+            for candidate in build_character_name_candidates(char):
+                if candidate.term in seen_terms:
+                    continue
+                seen_terms.add(candidate.term)
+                candidates.append(candidate)
+
+    return candidates
+
+
+def build_character_name_index(
+    candidates: Sequence[CharacterNameCandidate],
+) -> Dict[str, List[CharacterNameCandidate]]:
+    """Index candidates by first character so matching stays cheap."""
+    index: Dict[str, List[CharacterNameCandidate]] = {}
+    for candidate in candidates:
+        if not candidate.term:
+            continue
+        index.setdefault(candidate.term[0], []).append(candidate)
+
+    for group in index.values():
+        group.sort(key=lambda item: len(item.term), reverse=True)
+
+    return index
+
+
+def get_recent_character_name_index(
+    *,
+    force_refresh: bool = False,
+    cache_ttl_seconds: float = CHARACTER_NAME_CACHE_TTL_SECONDS,
+    desired_count: int = RECENT_CHARACTER_GAME_COUNT,
+    max_search: int = RECENT_CHARACTER_MAX_SEARCH,
+) -> Dict[str, List[CharacterNameCandidate]]:
+    """Return a cached index of recent character names and readings."""
+    global _CACHED_NAME_INDEX
+    global _CACHED_NAME_INDEX_AT
+
+    now = time.time()
+    cache_valid = (
+        not force_refresh
+        and _CACHED_NAME_INDEX is not None
+        and (now - _CACHED_NAME_INDEX_AT) < cache_ttl_seconds
+    )
+    if cache_valid:
+        return _CACHED_NAME_INDEX
+
+    candidates = build_recent_character_name_candidates(
+        desired_count=desired_count,
+        max_search=max_search,
+    )
+    _CACHED_NAME_INDEX = build_character_name_index(candidates)
+    _CACHED_NAME_INDEX_AT = now
+    return _CACHED_NAME_INDEX
+
+
+def text_contains_kanji(text: str) -> bool:
+    """Check whether the text contains any kanji characters."""
+    if not text:
+        return False
+    for char in text:
+        code = ord(char)
+        if (
+            0x4E00 <= code <= 0x9FFF
+            or 0x3400 <= code <= 0x4DBF
+            or 0x20000 <= code <= 0x2A6DF
+        ):
+            return True
+    return False
+
+
+def katakana_to_hiragana(text: str) -> str:
+    """Convert katakana to hiragana, leaving other characters untouched."""
+    out: List[str] = []
+    for char in text:
+        code = ord(char)
+        if 0x30A1 <= code <= 0x30F6:
+            out.append(chr(code - 0x60))
+        else:
+            out.append(char)
+    return "".join(out)
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _find_match_end_index(
+    tokens: Sequence[Dict[str, Any]],
+    start_index: int,
+    target_end: int,
+) -> Optional[int]:
+    for index in range(start_index, len(tokens)):
+        token_end = _coerce_int(tokens[index].get("end"))
+        if token_end is None:
+            return None
+        if token_end < target_end:
+            continue
+        return index if token_end == target_end else None
+    return None
+
+
+def merge_tokens_with_character_names(
+    text: str,
+    tokens: Sequence[Dict[str, Any]],
+    candidate_index: Optional[Dict[str, List[CharacterNameCandidate]]] = None,
+) -> List[Dict[str, Any]]:
+    """Merge token spans that match known character names from recent games."""
+    if not text or not tokens:
+        return list(tokens)
+
+    if candidate_index is None:
+        candidate_index = get_recent_character_name_index()
+    if not candidate_index:
+        return [dict(token) for token in tokens]
+
+    merged_tokens: List[Dict[str, Any]] = []
+    index = 0
+
+    while index < len(tokens):
+        token = tokens[index]
+        token_start = _coerce_int(token.get("start"))
+        if token_start is None or token_start < 0 or token_start >= len(text):
+            merged_tokens.append(dict(token))
+            index += 1
+            continue
+
+        best_candidate = None
+        best_end_index = None
+        for candidate in candidate_index.get(text[token_start], []):
+            candidate_end = token_start + len(candidate.term)
+            if candidate_end > len(text) or not text.startswith(candidate.term, token_start):
+                continue
+            end_index = _find_match_end_index(tokens, index, candidate_end)
+            if end_index is None:
+                continue
+            best_candidate = candidate
+            best_end_index = end_index
+            break
+
+        if best_candidate is None or best_end_index is None:
+            merged_tokens.append(dict(token))
+            index += 1
+            continue
+
+        merged_token = {
+            "word": text[token_start:token_start + len(best_candidate.term)],
+            "start": token_start,
+            "end": token_start + len(best_candidate.term),
+            "headword": best_candidate.headword,
+            "pos": "character-name",
+        }
+        if best_candidate.reading_katakana:
+            merged_token["reading"] = best_candidate.reading_katakana
+
+        merged_tokens.append(merged_token)
+        index = best_end_index + 1
+
+    return merged_tokens
+
+
+def tokens_to_furigana_segments(tokens: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert token output into furigana segments for the overlay."""
+    segments: List[Dict[str, Any]] = []
+
+    for token in tokens:
+        word = str(token.get("word") or "")
+        start = _coerce_int(token.get("start"))
+        end = _coerce_int(token.get("end"))
+        if not word or start is None or end is None:
+            continue
+
+        reading = str(token.get("reading") or "").strip()
+        reading_hiragana = katakana_to_hiragana(reading) if reading else ""
+        has_reading = (
+            bool(reading_hiragana)
+            and reading_hiragana != word
+            and text_contains_kanji(word)
+        )
+
+        segments.append(
+            {
+                "text": word,
+                "start": start,
+                "end": end,
+                "hasReading": has_reading,
+                "reading": reading_hiragana if has_reading else None,
+            }
+        )
+
+    return segments

--- a/GameSentenceMiner/web/yomitan_api.py
+++ b/GameSentenceMiner/web/yomitan_api.py
@@ -1,132 +1,12 @@
-"""
-Yomitan Dictionary API endpoint.
+"""Yomitan Dictionary API endpoint."""
 
-Generates a Yomitan-compatible dictionary from VNDB character data
-for the most recently played games.
-"""
-
-import json
 from flask import jsonify, make_response, request
-from typing import List
 
 from GameSentenceMiner.util.config.configuration import get_config, logger
-from GameSentenceMiner.util.database.games_table import GamesTable
 from GameSentenceMiner.util.yomitan_dict import YomitanDictBuilder
-
-
-def _has_character_data(game: GamesTable) -> bool:
-    """
-    Validate that a game actually has character entries, not just an empty JSON structure.
-    
-    Args:
-        game: GamesTable instance to validate
-        
-    Returns:
-        True if game has at least one character entry, False otherwise
-    """
-    if not game.vndb_character_data:
-        return False
-    
-    try:
-        # Parse JSON if it's a string
-        char_data = game.vndb_character_data
-        if isinstance(char_data, str):
-            char_data = json.loads(char_data)
-        
-        if not isinstance(char_data, dict):
-            return False
-        
-        # Check if any category has characters
-        # VNDB data structure: {"characters": {"main": [...], "primary": [...]}}
-        characters_obj = char_data.get("characters", {})
-        if not isinstance(characters_obj, dict):
-            return False
-        
-        categories = ["main", "primary", "side", "appears"]
-        for category in categories:
-            characters = characters_obj.get(category, [])
-            if isinstance(characters, list) and len(characters) > 0:
-                return True
-        
-        return False
-    except (json.JSONDecodeError, TypeError, AttributeError):
-        return False
-
-
-def get_recent_games(desired_count: int = 3, max_search: int = 50) -> List[GamesTable]:
-    """
-    Query the most recently played games with valid character data.
-    
-    This function searches through games ordered by their most recent play time
-    (based on game_lines timestamps) and validates that they actually contain
-    character entries (not just empty JSON structures). It returns games that
-    have valid, populated character data.
-    
-    Args:
-        desired_count: Number of valid games to return (default 3)
-        max_search: Maximum number of games to check (default 50)
-        
-    Returns:
-        List of GamesTable objects with validated vndb_character_data,
-        ordered by most recently played first
-    """
-    # Query games with character data, ordered by most recent play time
-    # Join with game_lines to get the MAX(timestamp) for each game
-    query = '''
-        SELECT g.id
-        FROM games g
-        LEFT JOIN (
-            SELECT game_id, MAX(timestamp) as last_played
-            FROM game_lines
-            WHERE game_id IS NOT NULL AND game_id != ''
-            GROUP BY game_id
-        ) gl ON g.id = gl.game_id
-        WHERE g.vndb_character_data IS NOT NULL
-          AND g.vndb_character_data != ''
-          AND g.vndb_character_data != '{}'
-        ORDER BY gl.last_played DESC NULLS LAST
-        LIMIT ?
-    '''
-    rows = GamesTable._db.fetchall(query, (max_search,))
-    
-    logger.info(f"Yomitan: Found {len(rows)} games with vndb_character_data field set (non-empty)")
-    
-    valid_games = []
-    checked_games = []  # For logging/debugging
-    
-    for row in rows:
-        game_id = row[0]
-        game = GamesTable.get(game_id)
-        
-        if not game:
-            continue
-        
-        game_title = game.title_original or game.title_romaji or game.title_english or game_id
-        
-        # Validate that the game actually has character entries
-        has_data = _has_character_data(game)
-        
-        if has_data:
-            valid_games.append(game)
-            checked_games.append((game_title, True, "Has character data"))
-            logger.info(f"Yomitan: ✓ '{game_title}' - VALID character data")
-            
-            # Stop once we have enough valid games
-            if len(valid_games) >= desired_count:
-                break
-        else:
-            checked_games.append((game_title, False, "Empty or invalid character data"))
-            # Log first few characters of the data to debug
-            data_preview = str(game.vndb_character_data)[:100] if game.vndb_character_data else "None"
-            logger.info(f"Yomitan: ✗ '{game_title}' - INVALID/EMPTY character data. Preview: {data_preview}")
-    
-    # Log summary
-    if valid_games:
-        logger.info(f"Yomitan: SUCCESS - Found {len(valid_games)} game(s) with valid character data out of {len(checked_games)} checked")
-    else:
-        logger.warning(f"Yomitan: FAILED - No games with valid character data found (checked {len(checked_games)} games)")
-    
-    return valid_games
+from GameSentenceMiner.util.yomitan_dict.character_names import (
+    get_recent_games_with_character_data,
+)
 
 
 def register_yomitan_api_routes(app):
@@ -205,7 +85,10 @@ def register_yomitan_api_routes(app):
             }), 400
         
         # 1. Get most recently played games with valid character data
-        recent_games = get_recent_games(desired_count=game_count, max_search=50)
+        recent_games = get_recent_games_with_character_data(
+            desired_count=game_count,
+            max_search=50,
+        )
         
         if not recent_games:
             return jsonify({
@@ -321,7 +204,10 @@ def register_yomitan_api_routes(app):
         builder = YomitanDictBuilder(download_url=download_url, game_count=game_count, spoiler_level=spoiler_level)
         
         # Get game titles for description (without processing all character data)
-        recent_games = get_recent_games(desired_count=game_count, max_search=50)
+        recent_games = get_recent_games_with_character_data(
+            desired_count=game_count,
+            max_search=50,
+        )
         for game in recent_games:
             game_title = game.title_original or game.title_romaji or game.title_english or ""
             if game_title:

--- a/tests/util/yomitan_dict/test_character_names.py
+++ b/tests/util/yomitan_dict/test_character_names.py
@@ -1,0 +1,131 @@
+from GameSentenceMiner.util.yomitan_dict.character_names import (
+    CharacterNameCandidate,
+    build_character_name_candidates,
+    build_character_name_index,
+    merge_tokens_with_character_names,
+    tokens_to_furigana_segments,
+)
+
+
+def test_build_character_name_candidates_matches_dictionary_variants(monkeypatch):
+    from GameSentenceMiner.util.yomitan_dict import character_names
+
+    parser = character_names._get_name_parser()
+    monkeypatch.setattr(
+        parser,
+        "generate_mixed_name_readings",
+        lambda *_args, **_kwargs: {"full": "ふる", "family": "かぞく", "given": "なまえ"},
+    )
+    monkeypatch.setattr(
+        parser,
+        "split_japanese_name",
+        lambda *_args, **_kwargs: {
+            "has_space": True,
+            "original": "星野 ルビー",
+            "combined": "星野ルビー",
+            "family": "星野",
+            "given": "ルビー",
+        },
+    )
+    monkeypatch.setattr(parser, "HONORIFIC_SUFFIXES", [("さん", "さん")])
+
+    candidates = build_character_name_candidates(
+        {
+            "name_original": "星野 ルビー",
+            "name": "Ruby Hoshino",
+            "aliases": ["アイドル"],
+        }
+    )
+
+    by_term = {candidate.term: candidate for candidate in candidates}
+    assert set(by_term) == {
+        "星野 ルビー",
+        "星野ルビー",
+        "星野",
+        "ルビー",
+        "星野さん",
+        "ルビーさん",
+        "星野ルビーさん",
+        "星野 ルビーさん",
+        "アイドル",
+        "アイドルさん",
+    }
+    assert by_term["星野ルビー"].reading_hiragana == "ふる"
+    assert by_term["星野ルビー"].reading_katakana == "フル"
+    assert by_term["アイドル"].headword == "星野ルビー"
+
+
+def test_merge_tokens_with_character_names_prefers_longest_recent_match():
+    tokens = [
+        {"word": "星野", "start": 0, "end": 2, "reading": "ホシノ"},
+        {"word": "ルビー", "start": 2, "end": 5, "reading": "ルビー"},
+        {"word": "が", "start": 5, "end": 6},
+    ]
+    candidates = [
+        CharacterNameCandidate(
+            term="星野ルビー",
+            reading_hiragana="ほしのるびー",
+            reading_katakana="ホシノルビー",
+            headword="星野ルビー",
+        ),
+        CharacterNameCandidate(
+            term="星野",
+            reading_hiragana="ほしの",
+            reading_katakana="ホシノ",
+            headword="星野ルビー",
+        ),
+    ]
+
+    merged = merge_tokens_with_character_names(
+        "星野ルビーが",
+        tokens,
+        build_character_name_index(candidates),
+    )
+
+    assert merged == [
+        {
+            "word": "星野ルビー",
+            "start": 0,
+            "end": 5,
+            "reading": "ホシノルビー",
+            "headword": "星野ルビー",
+            "pos": "character-name",
+        },
+        {"word": "が", "start": 5, "end": 6},
+    ]
+
+
+def test_tokens_to_furigana_segments_uses_character_name_readings():
+    segments = tokens_to_furigana_segments(
+        [
+            {
+                "word": "星野ルビー",
+                "start": 0,
+                "end": 5,
+                "reading": "ホシノルビー",
+            },
+            {
+                "word": "ルビー",
+                "start": 5,
+                "end": 8,
+                "reading": "ルビー",
+            },
+        ]
+    )
+
+    assert segments == [
+        {
+            "text": "星野ルビー",
+            "start": 0,
+            "end": 5,
+            "hasReading": True,
+            "reading": "ほしのるびー",
+        },
+        {
+            "text": "ルビー",
+            "start": 5,
+            "end": 8,
+            "hasReading": False,
+            "reading": None,
+        },
+    ]


### PR DESCRIPTION
## What I changed

I added a shared character-name helper at `GameSentenceMiner/util/yomitan_dict/character_names.py` and moved the recent-game character lookup logic there.

That helper now:
- finds the same recent games with populated `vndb_character_data` that the Yomitan character dictionary uses;
- builds the same searchable name variants the dictionary exports, including spaced names, combined names, family/given splits, honorific variants, and aliases;
- stores the canonical reading/headword for each variant;
- caches a recent-character index keyed by first character so the overlay bridge can match names cheaply;
- exposes helpers to merge token spans into character-name tokens and to convert token output into furigana segments.

I updated `GameSentenceMiner/web/yomitan_api.py` to reuse that helper instead of keeping its own copy of the recent-game character selection logic.

I updated `GSM_Overlay/input_server/mecab_bridge.py` so controller tokenization and overlay furigana use the database-backed character names after MeCab tokenization.

Concretely, the bridge now:
- keeps the existing JSON protocol unchanged;
- runs the normal MeCab tokenization first;
- post-processes the tokens by matching the text against the recent-character index;
- collapses matching spans into a single character-name token with the canonical reading and headword from the stored character data;
- uses those merged tokens when building furigana segments as well;
- falls back cleanly if the shared helper cannot be imported or if the character-name merge fails.

I also added focused coverage in `tests/util/yomitan_dict/test_character_names.py`.

## Why I did it this way

The problem was that controller tokenization was only as good as the generic tokenizer, and proper names are one of the cases where that tends to be weak.

The app already has a better source of truth for character names: the character data we store in the database and already turn into the Yomitan character dictionary. So the simplest fix was to hook the overlay/controller path into that existing data instead of inventing a separate name system.

I put the merge in `mecab_bridge.py` because that is already the choke point for controller tokenization and furigana. That keeps the change narrow:
- no new renderer protocol;
- no new settings;
- no changes to how the overlay asks for tokens;
- no need to duplicate name logic in JavaScript.

Reusing the same shared helper from both the Yomitan API and the overlay bridge also avoids drift. The character dictionary and the overlay/controller path now derive from the same recent-game selection and the same name variant generation rules.

## How the tests work

I added `tests/util/yomitan_dict/test_character_names.py` with three targeted checks:

1. `test_build_character_name_candidates_matches_dictionary_variants`
   This stubs the name parser and verifies that candidate generation produces the same kinds of variants the character dictionary expects: original spaced form, combined form, family/given parts, honorific variants, and aliases. It also checks that readings and canonical headwords are carried through.

2. `test_merge_tokens_with_character_names_prefers_longest_recent_match`
   This builds a token stream that would normally be split across multiple tokens and verifies that the merge step prefers the longest matching character name span, replacing it with one merged token carrying the stored reading/headword.

3. `test_tokens_to_furigana_segments_uses_character_name_readings`
   This verifies that furigana segment generation converts token readings correctly and only emits furigana when the merged token actually contains kanji and has a distinct reading.

I also reran the existing Yomitan name/dictionary tests to make sure the shared helper did not regress the current dictionary behavior:

```bash
C:\Users\Bee\Documents\GitHub\GameSentenceMiner\.venv\Scripts\python.exe -m pytest \
  tests/util/yomitan_dict/test_character_names.py \
  tests/util/yomitan_dict/test_name_parser.py \
  tests/util/yomitan_dict/test_dict_builder.py
```

And I ran a syntax smoke check on the touched runtime files:

```bash
C:\Users\Bee\Documents\GitHub\GameSentenceMiner\.venv\Scripts\python.exe -m py_compile \
  GameSentenceMiner\util\yomitan_dict\character_names.py \
  GameSentenceMiner\web\yomitan_api.py \
  GSM_Overlay\input_server\mecab_bridge.py
```
