### PR TITLE
Add cron task list tooling

### DIFF
--- a/GameSentenceMiner/util/cron/run_crons.py
+++ b/GameSentenceMiner/util/cron/run_crons.py
@@ -16,6 +16,8 @@ from typing import Optional
 from GameSentenceMiner.util.config.configuration import logger
 from GameSentenceMiner.util.database.cron_table import CronTable
 
+MANUAL_CRON_EXECUTION_TIMEOUT_SECONDS = 60.0
+
 
 class Crons(enum.Enum):
     POPULATE_GAMES = "populate_games"
@@ -50,6 +52,11 @@ def resolve_cron_task(task_name: str) -> Optional[Crons]:
             return cron
 
     return None
+
+
+def get_supported_cron_names() -> set[str]:
+    """Return all supported canonical cron names."""
+    return {cron.value for cron in Crons}
 
 
 def create_forced_cron(task: Crons, description: Optional[str] = None) -> MockCron:
@@ -412,6 +419,33 @@ class CronScheduler:
         async with self._lock:
             return await run_due_crons(force_task)
 
+    async def _execute_selected_cron_safe(self, cron) -> dict:
+        """Run a single cron row while sharing the scheduler lock."""
+        async with self._lock:
+            return await run_selected_cron(cron)
+
+    def run_cron_blocking(self, cron) -> dict:
+        """
+        Run a cron synchronously for API callers.
+
+        If the scheduler loop is active, execute within that loop so the shared
+        lock serializes manual reruns with background runs.
+        """
+        if self.is_running() and self.loop and self.loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(self._execute_selected_cron_safe(cron), self.loop)
+            try:
+                return future.result(timeout=MANUAL_CRON_EXECUTION_TIMEOUT_SECONDS)
+            except TimeoutError as exc:
+                future.cancel()
+                message = (
+                    f"Timed out waiting for manual cron execution after "
+                    f"{MANUAL_CRON_EXECUTION_TIMEOUT_SECONDS:.0f} seconds"
+                )
+                logger.error(message)
+                raise TimeoutError(message) from exc
+
+        return _run_crons_sync([cron])
+
     def is_running(self) -> bool:
         return self._running
 
@@ -422,6 +456,13 @@ async def run_due_crons(force_task: Optional["Crons"] = None) -> dict:
     do not block the async event loop (text input/websocket responsiveness).
     """
     return await asyncio.to_thread(_run_due_crons_sync, force_task)
+
+
+async def run_selected_cron(cron) -> dict:
+    """
+    Run a specific cron row in a worker thread.
+    """
+    return await asyncio.to_thread(_run_crons_sync, [cron])
 
 
 def _run_due_crons_sync(force_task: Optional["Crons"] = None) -> dict:

--- a/GameSentenceMiner/web/routes/cron_routes.py
+++ b/GameSentenceMiner/web/routes/cron_routes.py
@@ -2,16 +2,196 @@
 Cron Routes
 
 Routes for cron/background job operations:
-- Trigger Jiten upgrader
-- Trigger game population
-- Cron status endpoints
+- List scheduled tasks
+- Trigger a task manually and wait for completion
+- Keep the legacy Jiten upgrader endpoint working
 """
 
 from flask import Blueprint, jsonify
 
 from GameSentenceMiner.util.config.configuration import logger
+from GameSentenceMiner.util.cron.run_crons import (
+    cron_scheduler,
+    create_forced_cron,
+    get_supported_cron_names,
+    resolve_cron_task,
+)
+from GameSentenceMiner.util.database.cron_table import CronTable
 
 cron_bp = Blueprint("cron", __name__)
+
+
+def _get_canonical_task_name(task_name: str) -> str:
+    """Return the canonical cron task name for routing and dedupe decisions."""
+    resolved_task = resolve_cron_task(task_name)
+    if resolved_task:
+        return resolved_task.value
+    return (task_name or "").strip().lower()
+
+
+def _get_task_lookup_names(task_name: str) -> list[str]:
+    """Return exact names that may match a requested task."""
+    candidate_names = []
+
+    normalized_name = (task_name or "").strip().lower()
+    resolved_task = resolve_cron_task(task_name)
+    if resolved_task and resolved_task.value:
+        candidate_names.append(resolved_task.value)
+
+    if normalized_name and normalized_name not in candidate_names:
+        candidate_names.append(normalized_name)
+
+    return candidate_names
+
+
+def _get_task_row(task_name: str):
+    """Find the cron row backing a requested task, preferring canonical rows."""
+    canonical_name = _get_canonical_task_name(task_name)
+    candidate_rows = []
+
+    for candidate_name in _get_task_lookup_names(task_name):
+        task_row = CronTable.get_by_name(candidate_name)
+        if task_row:
+            candidate_rows.append(task_row)
+
+    for task_row in candidate_rows:
+        if task_row.name == canonical_name:
+            return task_row
+
+    return candidate_rows[0] if candidate_rows else None
+
+
+def _select_preferred_tasks(tasks: list[dict]) -> list[dict]:
+    """Collapse legacy aliases down to the canonical task card shown in the UI."""
+    preferred_by_canonical_name: dict[str, dict] = {}
+
+    for task in tasks:
+        canonical_name = task["canonical_name"]
+        existing = preferred_by_canonical_name.get(canonical_name)
+        if existing is None:
+            preferred_by_canonical_name[canonical_name] = task
+            continue
+
+        if task["name"] == canonical_name and existing["name"] != canonical_name:
+            preferred_by_canonical_name[canonical_name] = task
+
+    return list(preferred_by_canonical_name.values())
+
+
+def _serialize_cron_row(task_row: CronTable) -> dict:
+    """Serialize cron rows for the tasks API."""
+    resolved_task = resolve_cron_task(task_row.name)
+    schedule = task_row.schedule
+    next_run = task_row.next_run
+
+    # Legacy populate_games rows were stored as weekly, but they behave as one-off tasks.
+    if resolved_task and resolved_task.value == "populate_games":
+        schedule = "once"
+
+    if schedule == "once" and not task_row.enabled:
+        next_run = None
+
+    canonical_name = resolved_task.value if resolved_task else task_row.name
+    display_name = canonical_name.replace("_", " ").title()
+
+    return {
+        "id": task_row.id,
+        "name": task_row.name,
+        "display_name": display_name,
+        "canonical_name": canonical_name,
+        "description": task_row.description,
+        "schedule": schedule,
+        "enabled": task_row.enabled,
+        "last_run": task_row.last_run,
+        "next_run": next_run,
+        "can_rerun": task_row.name in get_supported_cron_names() or resolved_task is not None,
+    }
+
+
+def _run_task_and_wait(task_name: str):
+    """Execute a cron task synchronously, returning the detail payload and row."""
+    task_row = _get_task_row(task_name)
+    resolved_task = resolve_cron_task(task_name if task_row is None else task_row.name)
+
+    if resolved_task is None:
+        return None, None
+
+    if task_row is None:
+        task_row = create_forced_cron(resolved_task)
+
+    result = cron_scheduler.run_cron_blocking(task_row)
+    detail = result.get("details", [{}])[0] if result.get("details") else None
+
+    refreshed_row = None
+    if getattr(task_row, "id", -1) != -1:
+        refreshed_row = CronTable.get(task_row.id)
+
+    return detail, refreshed_row
+
+
+@cron_bp.route("/api/cron/tasks", methods=["GET"])
+def api_list_cron_tasks():
+    """Return all cron rows for the tools/tasks tab."""
+    serialized_tasks = _select_preferred_tasks([_serialize_cron_row(task) for task in CronTable.all()])
+    tasks = sorted(
+        serialized_tasks,
+        key=lambda task: (
+            task["next_run"] is None,
+            task["next_run"] if task["next_run"] is not None else float("inf"),
+            task["name"],
+        ),
+    )
+
+    return jsonify({"tasks": tasks}), 200
+
+
+@cron_bp.route("/api/cron/tasks/<task_name>/run", methods=["POST"])
+def api_run_cron_task(task_name: str):
+    """Manually run a cron task and wait for the result."""
+    try:
+        detail, refreshed_row = _run_task_and_wait(task_name)
+
+        if detail is None:
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "error": f"Unknown cron task: {task_name}",
+                    }
+                ),
+                404,
+            )
+
+        if not detail.get("success"):
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "error": detail.get("error") or "Cron task failed",
+                        "execution": detail,
+                        "task": _serialize_cron_row(refreshed_row) if refreshed_row else None,
+                    }
+                ),
+                500,
+            )
+
+        return (
+            jsonify(
+                {
+                    "status": "success",
+                    "execution": detail,
+                    "task": _serialize_cron_row(refreshed_row) if refreshed_row else None,
+                }
+            ),
+            200,
+        )
+
+    except TimeoutError as e:
+        logger.exception(f"Timed out running cron task {task_name}: {e}")
+        return jsonify({"status": "error", "error": str(e)}), 504
+    except Exception as e:
+        logger.exception(f"Error running cron task {task_name}: {e}")
+        return jsonify({"status": "error", "error": str(e)}), 500
 
 
 @cron_bp.route("/api/cron/jiten-upgrader/run", methods=["POST"])
@@ -23,25 +203,48 @@ def api_run_jiten_upgrader():
     to see if Jiten.moe now has entries for them, and auto-links if found.
     """
     try:
-        from GameSentenceMiner.util.cron.jiten_upgrader import upgrade_games_to_jiten
+        detail, _ = _run_task_and_wait("jiten_upgrader")
 
-        logger.info("Manual trigger: Running Jiten Upgrader")
-        result = upgrade_games_to_jiten()
+        if detail is None:
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "error": "Jiten Upgrader task is not available",
+                    }
+                ),
+                404,
+            )
 
-        return jsonify(
-            {
-                "status": "success",
-                "result": {
-                    "total_checked": result.get("total_checked", 0),
-                    "upgraded_to_jiten": result.get("upgraded_to_jiten", 0),
-                    "already_on_jiten": result.get("already_on_jiten", 0),
-                    "not_found_on_jiten": result.get("not_found_on_jiten", 0),
-                    "failed": result.get("failed", 0),
-                    "elapsed_time": result.get("elapsed_time", 0),
-                    "details": result.get("details", []),
-                },
-            }
-        ), 200
+        if not detail.get("success"):
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "error": detail.get("error") or "Failed to run Jiten Upgrader",
+                    }
+                ),
+                500,
+            )
+
+        result = detail.get("result", {})
+        return (
+            jsonify(
+                {
+                    "status": "success",
+                    "result": {
+                        "total_checked": result.get("total_checked", 0),
+                        "upgraded_to_jiten": result.get("upgraded_to_jiten", 0),
+                        "already_on_jiten": result.get("already_on_jiten", 0),
+                        "not_found_on_jiten": result.get("not_found_on_jiten", 0),
+                        "failed": result.get("failed", 0),
+                        "elapsed_time": result.get("elapsed_time", 0),
+                        "details": result.get("details", []),
+                    },
+                }
+            ),
+            200,
+        )
 
     except Exception as e:
         logger.exception(f"Error running Jiten Upgrader: {e}")

--- a/GameSentenceMiner/web/static/css/shared.css
+++ b/GameSentenceMiner/web/static/css/shared.css
@@ -437,6 +437,10 @@ h1 {
     overflow: hidden;
 }
 
+.management-card.full-width {
+    grid-column: 1 / -1;
+}
+
 .management-card:hover {
     transform: translateY(-2px);
     box-shadow: 0 8px 24px var(--shadow-color);
@@ -476,10 +480,30 @@ h1 {
     background: linear-gradient(90deg, var(--info-color), #4fc3f7);
 }
 
+.management-card.scheduled-tasks::before {
+    background: linear-gradient(90deg, #ff9800, #ffd54f);
+}
+
 .card-header {
     display: flex;
     align-items: center;
     margin-bottom: 20px;
+}
+
+.scheduled-tasks-header {
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.card-header-main {
+    display: flex;
+    align-items: flex-start;
+    gap: 15px;
+}
+
+.scheduled-tasks-header .card-icon {
+    margin-right: 0;
 }
 
 .card-icon {
@@ -1652,6 +1676,147 @@ input[type="date"].dashboard-date-input:hover {
     padding: 20px;
     flex: 1;
     overflow-y: auto;
+}
+
+.cron-tasks-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.cron-task-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.cron-task-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.cron-task-card-title {
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.cron-task-card-description {
+    margin: 6px 0 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+}
+
+.cron-task-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.cron-task-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.cron-task-badge.enabled {
+    background: rgba(40, 167, 69, 0.15);
+    color: var(--success-color);
+}
+
+.cron-task-badge.disabled {
+    background: rgba(220, 53, 69, 0.15);
+    color: var(--danger-color);
+}
+
+.cron-task-badge.schedule {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+}
+
+.cron-task-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+}
+
+.cron-task-meta-item {
+    background: var(--bg-tertiary);
+    border-radius: 10px;
+    padding: 12px;
+}
+
+.cron-task-meta-label {
+    display: block;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 4px;
+}
+
+.cron-task-meta-value {
+    color: var(--text-primary);
+    font-weight: 600;
+    word-break: break-word;
+}
+
+.cron-task-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.cron-tasks-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-height: 220px;
+    color: var(--text-secondary);
+    text-align: center;
+}
+
+.cron-tasks-empty-icon {
+    font-size: 40px;
+}
+
+@media (max-width: 768px) {
+    .scheduled-tasks-header,
+    .card-header-main {
+        flex-direction: column;
+    }
+
+    .scheduled-tasks-header .action-btn {
+        width: 100%;
+    }
+
+    .cron-task-card-header {
+        flex-direction: column;
+    }
+
+    .cron-task-badges {
+        justify-content: flex-start;
+    }
+
+    .cron-task-actions {
+        justify-content: stretch;
+    }
+
+    .cron-task-actions .action-btn {
+        width: 100%;
+    }
 }
 
 /* Individual Game Action Buttons */

--- a/GameSentenceMiner/web/static/js/database-cron-tasks.js
+++ b/GameSentenceMiner/web/static/js/database-cron-tasks.js
@@ -1,0 +1,203 @@
+// Database Cron Tasks Module
+// Dependencies: shared.js (escapeHtml), database-popups.js, database-helpers.js
+
+let cronTasks = [];
+let activeCronTaskRun = null;
+
+function initializeCronTasks() {
+    const tasksList = document.getElementById('tasksList');
+    if (!tasksList || tasksList.dataset.initialized === 'true') {
+        return;
+    }
+
+    const refreshButton = document.querySelector('[data-action="refreshCronTasks"]');
+
+    tasksList.addEventListener('click', async (event) => {
+        const rerunButton = event.target.closest('[data-action="rerunCronTask"]');
+        if (!rerunButton) {
+            return;
+        }
+
+        const taskName = rerunButton.dataset.taskName;
+        if (!taskName) {
+            return;
+        }
+
+        await rerunCronTask(taskName);
+    });
+
+    if (refreshButton) {
+        refreshButton.addEventListener('click', () => {
+            void loadCronTasks();
+        });
+    }
+
+    tasksList.dataset.initialized = 'true';
+    void loadCronTasks();
+}
+
+async function loadCronTasks() {
+    const loadingIndicator = document.getElementById('tasksLoadingIndicator');
+    const tasksContent = document.getElementById('tasksContent');
+    const emptyState = document.getElementById('tasksEmptyState');
+
+    if (!loadingIndicator || !tasksContent || !emptyState) {
+        return;
+    }
+
+    loadingIndicator.style.display = 'flex';
+    tasksContent.style.display = 'none';
+    emptyState.style.display = 'none';
+
+    try {
+        const response = await fetch('/api/cron/tasks');
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.error || 'Failed to load tasks');
+        }
+
+        cronTasks = Array.isArray(data.tasks) ? data.tasks : [];
+        renderCronTasks();
+
+        if (cronTasks.length === 0) {
+            emptyState.style.display = 'flex';
+        } else {
+            tasksContent.style.display = 'block';
+        }
+    } catch (error) {
+        console.error('Error loading cron tasks:', error);
+        showDatabaseErrorPopup(`Failed to load tasks: ${error.message}`);
+        emptyState.style.display = 'flex';
+    } finally {
+        loadingIndicator.style.display = 'none';
+    }
+}
+
+function renderCronTasks() {
+    const tasksList = document.getElementById('tasksList');
+    if (!tasksList) {
+        return;
+    }
+
+    tasksList.innerHTML = cronTasks.map((task) => {
+        const isRunning = activeCronTaskRun === task.name;
+        const buttonLabel = isRunning ? 'Running...' : 'Rerun';
+        const buttonDisabled = isRunning || !task.can_rerun;
+        const enabledLabel = task.enabled ? 'Enabled' : 'Disabled';
+        const enabledClass = task.enabled ? 'enabled' : 'disabled';
+        const displayName = escapeHtml(task.display_name || task.name);
+        const description = escapeHtml(task.description || 'No description available.');
+        const schedule = escapeHtml(formatCronSchedule(task.schedule));
+        const lastRun = escapeHtml(formatUnixTimestamp(task.last_run, 'Never'));
+        const nextRun = escapeHtml(formatUnixTimestamp(task.next_run, 'Not scheduled'));
+
+        return `
+            <div class="cron-task-card">
+                <div class="cron-task-card-header">
+                    <div>
+                        <h4 class="cron-task-card-title">${displayName}</h4>
+                        <p class="cron-task-card-description">${description}</p>
+                    </div>
+                    <div class="cron-task-badges">
+                        <span class="cron-task-badge ${enabledClass}">${enabledLabel}</span>
+                        <span class="cron-task-badge schedule">${schedule}</span>
+                    </div>
+                </div>
+                <div class="cron-task-meta">
+                    <div class="cron-task-meta-item">
+                        <span class="cron-task-meta-label">Last Run</span>
+                        <span class="cron-task-meta-value">${lastRun}</span>
+                    </div>
+                    <div class="cron-task-meta-item">
+                        <span class="cron-task-meta-label">Next Run</span>
+                        <span class="cron-task-meta-value">${nextRun}</span>
+                    </div>
+                    <div class="cron-task-meta-item">
+                        <span class="cron-task-meta-label">Task Key</span>
+                        <span class="cron-task-meta-value">${escapeHtml(task.name)}</span>
+                    </div>
+                </div>
+                <div class="cron-task-actions">
+                    <button
+                        class="action-btn primary"
+                        data-action="rerunCronTask"
+                        data-task-name="${escapeHtml(task.name)}"
+                        ${buttonDisabled ? 'disabled' : ''}
+                    >
+                        ${buttonLabel}
+                    </button>
+                </div>
+            </div>
+        `;
+    }).join('');
+}
+
+async function rerunCronTask(taskName) {
+    activeCronTaskRun = taskName;
+    renderCronTasks();
+
+    try {
+        const response = await fetch(`/api/cron/tasks/${encodeURIComponent(taskName)}/run`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+            throw new Error(data.error || 'Failed to rerun task');
+        }
+
+        if (data.task) {
+            cronTasks = cronTasks.map((task) => task.name === data.task.name ? data.task : task);
+        }
+
+        showDatabaseSuccessPopup(buildCronTaskSuccessMessage(data));
+        await loadCronTasks();
+    } catch (error) {
+        console.error(`Error rerunning cron task ${taskName}:`, error);
+        showDatabaseErrorPopup(`Failed to rerun task: ${error.message}`);
+    } finally {
+        activeCronTaskRun = null;
+        renderCronTasks();
+    }
+}
+
+function formatCronSchedule(schedule) {
+    if (!schedule) {
+        return 'Unknown';
+    }
+
+    return schedule
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function buildCronTaskSuccessMessage(data) {
+    const task = data.task || {};
+    const execution = data.execution || {};
+    const result = execution.result || {};
+    const taskLabel = task.display_name || task.name || execution.task_name || execution.name || 'Task';
+
+    if (result.skipped) {
+        return `${taskLabel} skipped: ${result.reason || 'no work to do'}.`;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(result, 'upgraded_to_jiten')) {
+        return `${taskLabel} finished. Upgraded ${result.upgraded_to_jiten || 0} games.`;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(result, 'processed')) {
+        return `${taskLabel} finished. Processed ${result.processed || 0} items.`;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(result, 'created')) {
+        return `${taskLabel} finished. Created ${result.created || 0} games.`;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(result, 'action')) {
+        return `${taskLabel} finished with action: ${result.action}.`;
+    }
+
+    return `${taskLabel} finished successfully.`;
+}

--- a/GameSentenceMiner/web/static/js/database.js
+++ b/GameSentenceMiner/web/static/js/database.js
@@ -162,6 +162,10 @@ class DatabaseManager {
         if (typeof initializeDatabasePopups === 'function') {
             initializeDatabasePopups();
         }
+
+        if (typeof initializeCronTasks === 'function') {
+            initializeCronTasks();
+        }
     }
     
     /**

--- a/GameSentenceMiner/web/templates/database.html
+++ b/GameSentenceMiner/web/templates/database.html
@@ -231,6 +231,36 @@
             </div>
         </div>
 
+        <div class="management-card scheduled-tasks full-width">
+            <div class="card-header scheduled-tasks-header">
+                <div class="card-header-main">
+                    <div class="card-icon">⏱️</div>
+                    <div>
+                        <h2 class="card-title">Scheduled Tasks</h2>
+                        <p class="card-description" style="margin: 8px 0 0;">
+                            GSM regularly runs tasks. If you need to make GSM manually run a task, this is the place to do it. For example, if your stats are lagging you can run "Daily Stats Rollup". Or you can run "Jiten Sync" to sync with Jiten/VNDB/Anilist etc.
+                        </p>
+                    </div>
+                </div>
+                <button class="action-btn primary" data-action="refreshCronTasks">
+                    Refresh Tasks
+                </button>
+            </div>
+
+            <div id="tasksLoadingIndicator" class="loading-indicator">
+                <div class="spinner"></div>
+                <span>Loading tasks...</span>
+            </div>
+
+            <div id="tasksContent" style="display: none;">
+                <div id="tasksList" class="cron-tasks-list"></div>
+            </div>
+
+            <div id="tasksEmptyState" class="cron-tasks-empty" style="display: none;">
+                <div class="cron-tasks-empty-icon">⏱️</div>
+                <p>No scheduled tasks found.</p>
+            </div>
+        </div>
     </div>
 
     {% include 'components/settings-modal.html' %}
@@ -1266,6 +1296,7 @@
 <script src="/static/js/unified-search.js"></script>
 <script src="/static/js/database-jiten-integration.js"></script>
 <script src="/static/js/database-game-operations.js"></script>
+<script src="/static/js/database-cron-tasks.js"></script>
 <script src="/static/js/database-third-party-stats.js"></script>
 <script src="/static/js/database-exstatic-import.js"></script>
 

--- a/tests/util/cron/test_run_crons.py
+++ b/tests/util/cron/test_run_crons.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from GameSentenceMiner.util.cron.run_crons import (
+    MANUAL_CRON_EXECUTION_TIMEOUT_SECONDS,
+    CronScheduler,
+    MockCron,
+)
+
+
+def test_run_cron_blocking_uses_bounded_timeout_when_scheduler_is_running(monkeypatch):
+    scheduler = CronScheduler()
+    scheduler._running = True
+    scheduler.loop = SimpleNamespace(is_running=lambda: True)
+
+    cancel_calls = []
+    observed_timeouts = []
+
+    class _FakeFuture:
+        def result(self, timeout=None):
+            observed_timeouts.append(timeout)
+            raise TimeoutError("hung")
+
+        def cancel(self):
+            cancel_calls.append(True)
+            return True
+
+    monkeypatch.setattr(
+        "GameSentenceMiner.util.cron.run_crons.asyncio.run_coroutine_threadsafe",
+        lambda coro, loop: (coro.close() or _FakeFuture()),
+    )
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for manual cron execution"):
+        scheduler.run_cron_blocking(MockCron(id=1, name="daily_stats_rollup", description="test"))
+
+    assert observed_timeouts == [MANUAL_CRON_EXECUTION_TIMEOUT_SECONDS]
+    assert cancel_calls == [True]
+
+
+def test_run_cron_blocking_returns_result_before_timeout_when_scheduler_is_running(monkeypatch):
+    scheduler = CronScheduler()
+    scheduler._running = True
+    scheduler.loop = SimpleNamespace(is_running=lambda: True)
+
+    observed_timeouts = []
+    expected = {"details": [{"success": True, "result": {"ok": 1}}]}
+
+    class _FakeFuture:
+        def result(self, timeout=None):
+            observed_timeouts.append(timeout)
+            return expected
+
+        def cancel(self):
+            raise AssertionError("cancel() should not be called for successful runs")
+
+    monkeypatch.setattr(
+        "GameSentenceMiner.util.cron.run_crons.asyncio.run_coroutine_threadsafe",
+        lambda coro, loop: (coro.close() or _FakeFuture()),
+    )
+
+    result = scheduler.run_cron_blocking(MockCron(id=1, name="daily_stats_rollup", description="test"))
+
+    assert result == expected
+    assert observed_timeouts == [MANUAL_CRON_EXECUTION_TIMEOUT_SECONDS]

--- a/tests/web/test_cron_routes.py
+++ b/tests/web/test_cron_routes.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+import flask
+
+from GameSentenceMiner.util.database import db as db_mod
+from GameSentenceMiner.web.routes.cron_routes import cron_bp
+
+CronTable = db_mod.CronTable
+SQLiteDB = db_mod.SQLiteDB
+
+
+def _make_client():
+    app = flask.Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(cron_bp)
+    return app.test_client()
+
+
+def test_list_cron_tasks_sorts_using_serialized_next_run():
+    original_db = CronTable._db
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    try:
+        test_db = SQLiteDB(path)
+        CronTable.set_db(test_db)
+
+        CronTable.create_cron_entry(
+            name="daily_stats_rollup",
+            description="Daily stats rollup",
+            next_run=2000.0,
+            schedule="daily",
+            enabled=True,
+        )
+        CronTable.create_cron_entry(
+            name="populate_games",
+            description="One-time populate",
+            next_run=1000.0,
+            schedule="weekly",
+            enabled=False,
+        )
+
+        client = _make_client()
+        response = client.get("/api/cron/tasks")
+
+        assert response.status_code == 200
+        tasks = response.get_json()["tasks"]
+        assert [task["name"] for task in tasks] == ["daily_stats_rollup", "populate_games"]
+        assert tasks[1]["next_run"] is None
+    finally:
+        CronTable.set_db(original_db)
+        if "test_db" in locals():
+            test_db.close()
+
+        os.unlink(path)
+
+
+def test_list_cron_tasks_includes_user_plugins_task():
+    original_db = CronTable._db
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    try:
+        test_db = SQLiteDB(path)
+        CronTable.set_db(test_db)
+
+        CronTable.create_cron_entry(
+            name="user_plugins",
+            description="User plugins task",
+            next_run=1000.0,
+            schedule="minutely",
+            enabled=True,
+        )
+
+        client = _make_client()
+        response = client.get("/api/cron/tasks")
+
+        assert response.status_code == 200
+        tasks = response.get_json()["tasks"]
+        assert [task["name"] for task in tasks] == ["user_plugins"]
+        assert tasks[0]["canonical_name"] == "user_plugins"
+    finally:
+        CronTable.set_db(original_db)
+        if "test_db" in locals():
+            test_db.close()
+
+        os.unlink(path)
+
+
+def test_run_user_plugins_task_uses_canonical_row(monkeypatch):
+    original_db = CronTable._db
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    captured = {}
+
+    try:
+        test_db = SQLiteDB(path)
+        CronTable.set_db(test_db)
+
+        canonical = CronTable.create_cron_entry(
+            name="user_plugins",
+            description="User plugins task",
+            next_run=1000.0,
+            schedule="minutely",
+            enabled=True,
+        )
+
+        def fake_run_cron_blocking(task_row):
+            captured["task_name"] = task_row.name
+            captured["task_id"] = task_row.id
+            return {"details": [{"success": True, "result": {}}]}
+
+        monkeypatch.setattr(
+            "GameSentenceMiner.web.routes.cron_routes.cron_scheduler.run_cron_blocking",
+            fake_run_cron_blocking,
+        )
+
+        client = _make_client()
+        response = client.post("/api/cron/tasks/user_plugins/run")
+
+        assert response.status_code == 200
+        assert captured == {"task_name": "user_plugins", "task_id": canonical.id}
+        assert response.get_json()["task"]["name"] == "user_plugins"
+    finally:
+        CronTable.set_db(original_db)
+        if "test_db" in locals():
+            test_db.close()
+
+        os.unlink(path)


### PR DESCRIPTION
## Summary
- restore the cron task list UI on the Tools page
- restore the `/api/cron/tasks` and manual rerun plumbing needed by that UI
- keep the task-list-specific tests with this follow-up PR

## Notes
- split out from #411 so that `pr-411` stays focused on bug fixes and stability
- this PR targets `pr-411` and should merge after the bug-fix branch
