### PR TITLE
[codex] Add batched Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/GSM_Overlay"
+      - "/texthooker"
+    schedule:
+      interval: "monthly"
+      time: "07:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 30
+      include:
+        - "*"
+    groups:
+      npm-batch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "07:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 30
+      include:
+        - "*"
+    groups:
+      uv-batch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "monthly"
       time: "07:00"
-      timezone: "Europe/London"
+      timezone: "America/New_York"
     cooldown:
       default-days: 30
       include:
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "monthly"
       time: "07:00"
-      timezone: "Europe/London"
+      timezone: "America/New_York"
     cooldown:
       default-days: 30
       include:


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration scoped to the existing npm package roots and the root uv lockfile.

The config batches version update PRs per ecosystem and applies a 30-day cooldown before normal version updates are eligible, reducing exposure to freshly published package releases while still allowing Dependabot security behavior to operate separately.

## Scope

- npm directories: `/`, `/GSM_Overlay`, `/texthooker`
- uv directory: `/`

## Validation

- Parsed `.github/dependabot.yml` with Python YAML loader
- Ran `git diff --check HEAD^ HEAD`