### PR TITLE
Use combined rollup + third-party first date for stats defaults

### DIFF
--- a/GameSentenceMiner/util/database/third_party_stats_table.py
+++ b/GameSentenceMiner/util/database/third_party_stats_table.py
@@ -51,6 +51,13 @@ class ThirdPartyStatsTable(SQLiteDBTable):
         self.created_at = created_at if created_at is not None else time.time()
 
     @classmethod
+    def get_first_date(cls) -> Optional[str]:
+        """Get the earliest date with third-party stats data."""
+        row = cls._db.fetchone(f"SELECT date FROM {cls._table} ORDER BY date ASC LIMIT 1")
+        result = row[0] if row else None
+        return result
+
+    @classmethod
     def get_date_range(cls, start_date: str, end_date: str) -> List["ThirdPartyStatsTable"]:
         """Get all third-party stats rows within a date range (inclusive)."""
         rows = cls._db.fetchall(

--- a/GameSentenceMiner/web/rollup_stats.py
+++ b/GameSentenceMiner/web/rollup_stats.py
@@ -42,6 +42,16 @@ def get_third_party_stats_by_date(start_date: str, end_date: str) -> Dict[str, D
     return ThirdPartyStatsTable.aggregate_by_date(start_date, end_date)
 
 
+def get_first_date_combined() -> Optional[str]:
+    """Get the earliest date across both rollup and third-party stats."""
+    from GameSentenceMiner.util.database.stats_rollup_table import StatsRollupTable
+    from GameSentenceMiner.util.database.third_party_stats_table import ThirdPartyStatsTable
+
+    candidates = [d for d in (StatsRollupTable.get_first_date(), ThirdPartyStatsTable.get_first_date()) if d]
+    result = min(candidates) if candidates else None
+    return result
+
+
 def enrich_aggregated_stats(stats: Dict, third_party_by_date: Optional[Dict] = None) -> Dict:
     """
     Add third-party characters and time into an aggregated stats dict.

--- a/GameSentenceMiner/web/stats_api.py
+++ b/GameSentenceMiner/web/stats_api.py
@@ -27,6 +27,7 @@ from GameSentenceMiner.util.jiten_difficulty import get_jiten_difficulty_label
 from GameSentenceMiner.web.rollup_stats import (
     calculate_difficulty_speed_from_rollup,
     calculate_genre_tag_stats_from_rollup,
+    get_first_date_combined,
 )
 from GameSentenceMiner.util.stats.stats_util import (
     count_cards_from_line,
@@ -858,7 +859,7 @@ def _build_all_games_stats(
     if completed_games_count is None:
         completed_games_count = len(GamesTable.get_all_completed() or [])
     if first_date is None:
-        first_date = StatsRollupTable.get_first_date()
+        first_date = get_first_date_combined()
 
     all_games_stats: dict = {
         "total_characters": combined_stats.get("total_characters", 0),
@@ -2092,8 +2093,8 @@ def register_stats_api_routes(app):
                 if end_date < start_date:
                     start_date, end_date = end_date, start_date
             elif use_all_time:
-                # Get all data from first rollup date to today
-                first_rollup_date = StatsRollupTable.get_first_date()
+                # Get all data from first rollup/third-party date to today
+                first_rollup_date = get_first_date_combined()
                 if not first_rollup_date:
                     return jsonify({"labels": [], "timeData": [], "charsData": [], "speedData": []}), 200
 

--- a/GameSentenceMiner/web/stats_repository.py
+++ b/GameSentenceMiner/web/stats_repository.py
@@ -12,6 +12,7 @@ from GameSentenceMiner.util.database.db import (
 )
 from GameSentenceMiner.util.database.games_table import GamesTable
 from GameSentenceMiner.util.database.stats_rollup_table import StatsRollupTable
+from GameSentenceMiner.web.rollup_stats import get_first_date_combined
 
 
 class StatsLineRecord:
@@ -275,7 +276,7 @@ def get_date_range_params(
         start_date_str = datetime.date.fromtimestamp(start_timestamp).strftime("%Y-%m-%d")
         end_date_str = datetime.date.fromtimestamp(end_timestamp).strftime("%Y-%m-%d")
     else:
-        first_rollup_date = StatsRollupTable.get_first_date()
+        first_rollup_date = get_first_date_combined()
         start_date_str = first_rollup_date if first_rollup_date else today_str
         end_date_str = today_str
 

--- a/GameSentenceMiner/web/texthooking_page.py
+++ b/GameSentenceMiner/web/texthooking_page.py
@@ -1192,10 +1192,10 @@ def stats():
         get_master_config,
         get_stats_config,
     )
-    from GameSentenceMiner.util.database.stats_rollup_table import StatsRollupTable
+    from GameSentenceMiner.web.rollup_stats import get_first_date_combined
 
-    # Get first date from rollup table to avoid extra API call on page load
-    first_rollup_date = StatsRollupTable.get_first_date()
+    # Get first date from rollup/third-party stats to avoid extra API call on page load
+    first_rollup_date = get_first_date_combined()
 
     return render_template(
         "stats.html",


### PR DESCRIPTION
The default value in the input field for "from date" on /stats page didn't take into consideration third party readings. Made this check for the earliest date from third party reading + rollup combined.
I've built this and tested it