### PR TITLE
feat(overlay): add mouseclick forwarding bind

### DIFF
--- a/GSM_Overlay/gamepad.js
+++ b/GSM_Overlay/gamepad.js
@@ -525,6 +525,7 @@ class GamepadHandler {
       confirmButton: options.confirmButton ?? 0, // A button (optional - auto-confirm enabled)
       cancelButton: options.cancelButton ?? 1, // B button
       forwardEnterButton: options.forwardEnterButton ?? -1, // Disabled by default; forwards Enter to target game window
+      forwardMouseClickButton: options.forwardMouseClickButton ?? -1, // Disabled by default; forwards a left mouse click to the target game window
       forwardSpaceButton: options.forwardSpaceButton ?? -1, // Disabled by default; forwards Space to target game window
       forwardCtrlButton: options.forwardCtrlButton ?? -1, // Disabled by default; forwards Ctrl (skip) to target game window
       forwardEscapeButton: options.forwardEscapeButton ?? -1, // Disabled by default; forwards Escape to target game window
@@ -592,6 +593,7 @@ class GamepadHandler {
       keyboardConfirmKey: options.keyboardConfirmKey || 'Enter',
       keyboardCancelKey: options.keyboardCancelKey || 'Escape',
       keyboardForwardEnterKey: options.keyboardForwardEnterKey || null,
+      keyboardForwardMouseClickKey: options.keyboardForwardMouseClickKey || null,
       keyboardForwardSpaceKey: options.keyboardForwardSpaceKey || null,
       keyboardForwardCtrlKey: options.keyboardForwardCtrlKey || null,
       keyboardForwardEscapeKey: options.keyboardForwardEscapeKey || null,
@@ -1341,6 +1343,7 @@ class GamepadHandler {
       confirmButton: normalizeGamepadBindingValue(this.config.confirmButton, 0),
       cancelButton: normalizeGamepadBindingValue(this.config.cancelButton, 1),
       forwardEnterButton: normalizeGamepadBindingValue(this.config.forwardEnterButton, -1),
+      forwardMouseClickButton: normalizeGamepadBindingValue(this.config.forwardMouseClickButton, -1),
       forwardSpaceButton: normalizeGamepadBindingValue(this.config.forwardSpaceButton, -1),
       forwardCtrlButton: normalizeGamepadBindingValue(this.config.forwardCtrlButton, -1),
       forwardEscapeButton: normalizeGamepadBindingValue(this.config.forwardEscapeButton, -1),
@@ -1359,6 +1362,7 @@ class GamepadHandler {
       confirmKey: normalizeKeyboardBindingValue(this.config.keyboardConfirmKey, 'Enter'),
       cancelKey: normalizeKeyboardBindingValue(this.config.keyboardCancelKey, 'Escape'),
       forwardEnterKey: normalizeKeyboardBindingValue(this.config.keyboardForwardEnterKey),
+      forwardMouseClickKey: normalizeKeyboardBindingValue(this.config.keyboardForwardMouseClickKey),
       forwardSpaceKey: normalizeKeyboardBindingValue(this.config.keyboardForwardSpaceKey),
       forwardCtrlKey: normalizeKeyboardBindingValue(this.config.keyboardForwardCtrlKey),
       forwardEscapeKey: normalizeKeyboardBindingValue(this.config.keyboardForwardEscapeKey),
@@ -2671,6 +2675,12 @@ class GamepadHandler {
       return;
     }
 
+    // Forward mouse click
+    if (keyboardEventMatchesBinding(kb.forwardMouseClickKey, keyName, keys, mods)) {
+      this.forwardMouseClickToTargetWindow();
+      return;
+    }
+
     // Forward other curated keys (space/ctrl/escape) to the target game window
     for (const { binding, key } of this.getForwardKeyKeyboardBindings()) {
       if (keyboardEventMatchesBinding(binding, keyName, keys, mods)) {
@@ -2849,6 +2859,11 @@ class GamepadHandler {
       return;
     }
 
+    if (this.matchesButtonBindingDown(this.buttonBindings.forwardMouseClickButton, device, buttonIndex)) {
+      this.forwardMouseClickToTargetWindow();
+      return;
+    }
+
     for (const { binding, key } of this.getForwardKeyButtonBindings()) {
       if (this.matchesButtonBindingDown(binding, device, buttonIndex)) {
         this.forwardKeyToTargetWindow(key);
@@ -2910,6 +2925,15 @@ class GamepadHandler {
     }
 
     ipc.send('gamepad-forward-enter');
+  }
+
+  forwardMouseClickToTargetWindow() {
+    const ipc = this.getIpcRenderer();
+    if (!ipc) {
+      return;
+    }
+
+    ipc.send('gamepad-forward-key', 'mouseclick');
   }
 
   // Curated keys (besides Enter) that can be forwarded to the target game window.
@@ -6384,6 +6408,7 @@ class GamepadHandler {
       safeConfig.confirmButton = this.describeButtonBinding(this.buttonBindings.confirmButton);
       safeConfig.cancelButton = this.describeButtonBinding(this.buttonBindings.cancelButton);
       safeConfig.forwardEnterButton = this.describeButtonBinding(this.buttonBindings.forwardEnterButton);
+      safeConfig.forwardMouseClickButton = this.describeButtonBinding(this.buttonBindings.forwardMouseClickButton);
       safeConfig.forwardSpaceButton = this.describeButtonBinding(this.buttonBindings.forwardSpaceButton);
       safeConfig.forwardCtrlButton = this.describeButtonBinding(this.buttonBindings.forwardCtrlButton);
       safeConfig.forwardEscapeButton = this.describeButtonBinding(this.buttonBindings.forwardEscapeButton);

--- a/GSM_Overlay/index.html
+++ b/GSM_Overlay/index.html
@@ -3995,6 +3995,9 @@ background: rgba(202, 12, 12, 0.692);
     if (newsettings.gamepadForwardEnterButton !== undefined) {
       gamepadSettings.forwardEnterButton = newsettings.gamepadForwardEnterButton;
     }
+    if (newsettings.gamepadForwardMouseClickButton !== undefined) {
+      gamepadSettings.forwardMouseClickButton = newsettings.gamepadForwardMouseClickButton;
+    }
     if (newsettings.gamepadForwardSpaceButton !== undefined) {
       gamepadSettings.forwardSpaceButton = newsettings.gamepadForwardSpaceButton;
     }
@@ -4691,6 +4694,7 @@ background: rgba(202, 12, 12, 0.692);
     confirmButton: 0, // A
     cancelButton: 1, // B
     forwardEnterButton: -1, // Disabled
+    forwardMouseClickButton: -1, // Disabled
     forwardSpaceButton: -1, // Disabled
     forwardCtrlButton: -1, // Disabled
     forwardEscapeButton: -1, // Disabled
@@ -4719,6 +4723,7 @@ background: rgba(202, 12, 12, 0.692);
     keyboardConfirmKey: 'Enter',
     keyboardCancelKey: 'Escape',
     keyboardForwardEnterKey: null,
+    keyboardForwardMouseClickKey: null,
     keyboardForwardSpaceKey: null,
     keyboardForwardCtrlKey: null,
     keyboardForwardEscapeKey: null,
@@ -4736,7 +4741,7 @@ background: rgba(202, 12, 12, 0.692);
   // Keyboard setting keys that map directly (settingKey in settings.html -> gamepadSettings key)
   const KEYBOARD_SETTING_KEYS = [
     'keyboardModifierKey', 'keyboardToggleKey', 'keyboardConfirmKey', 'keyboardCancelKey',
-    'keyboardForwardEnterKey', 'keyboardForwardSpaceKey', 'keyboardForwardCtrlKey', 'keyboardForwardEscapeKey',
+    'keyboardForwardEnterKey', 'keyboardForwardMouseClickKey', 'keyboardForwardSpaceKey', 'keyboardForwardCtrlKey', 'keyboardForwardEscapeKey',
     'keyboardManualOverlayScanKey', 'keyboardTokenModeToggleKey',
     'keyboardNextEntryKey', 'keyboardPrevEntryKey',
     'keyboardNavigateUp', 'keyboardNavigateDown', 'keyboardNavigateLeft', 'keyboardNavigateRight',
@@ -4785,6 +4790,7 @@ background: rgba(202, 12, 12, 0.692);
       confirmButton: gamepadSettings.confirmButton,
       cancelButton: gamepadSettings.cancelButton,
       forwardEnterButton: gamepadSettings.forwardEnterButton,
+      forwardMouseClickButton: gamepadSettings.forwardMouseClickButton,
       forwardSpaceButton: gamepadSettings.forwardSpaceButton,
       forwardCtrlButton: gamepadSettings.forwardCtrlButton,
       forwardEscapeButton: gamepadSettings.forwardEscapeButton,
@@ -4814,6 +4820,7 @@ background: rgba(202, 12, 12, 0.692);
       keyboardConfirmKey: gamepadSettings.keyboardConfirmKey,
       keyboardCancelKey: gamepadSettings.keyboardCancelKey,
       keyboardForwardEnterKey: gamepadSettings.keyboardForwardEnterKey,
+      keyboardForwardMouseClickKey: gamepadSettings.keyboardForwardMouseClickKey,
       keyboardForwardSpaceKey: gamepadSettings.keyboardForwardSpaceKey,
       keyboardForwardCtrlKey: gamepadSettings.keyboardForwardCtrlKey,
       keyboardForwardEscapeKey: gamepadSettings.keyboardForwardEscapeKey,
@@ -5172,6 +5179,10 @@ background: rgba(202, 12, 12, 0.692);
     }
     if (updatedSettings.gamepadForwardEnterButton !== undefined) {
       gamepadSettings.forwardEnterButton = updatedSettings.gamepadForwardEnterButton;
+      needsLifecycleSync = true;
+    }
+    if (updatedSettings.gamepadForwardMouseClickButton !== undefined) {
+      gamepadSettings.forwardMouseClickButton = updatedSettings.gamepadForwardMouseClickButton;
       needsLifecycleSync = true;
     }
     if (updatedSettings.gamepadForwardSpaceButton !== undefined) {

--- a/GSM_Overlay/main.js
+++ b/GSM_Overlay/main.js
@@ -486,6 +486,7 @@ const DEFAULT_USER_SETTINGS = Object.freeze({
   "gamepadConfirmButton": 0, // A
   "gamepadCancelButton": 1, // B
   "gamepadForwardEnterButton": -1, // Disabled by default; forwards Enter to target game window
+  "gamepadForwardMouseClickButton": -1, // Disabled by default; forwards a left mouse click to target game window
   "gamepadForwardSpaceButton": -1, // Disabled by default; forwards Space to target game window
   "gamepadForwardCtrlButton": -1, // Disabled by default; forwards Ctrl (skip) to target game window
   "gamepadForwardEscapeButton": -1, // Disabled by default; forwards Escape to target game window
@@ -6212,6 +6213,7 @@ app.whenReady().then(async () => {
       case "gamepadConfirmButton":
       case "gamepadCancelButton":
       case "gamepadForwardEnterButton":
+      case "gamepadForwardMouseClickButton":
       case "gamepadForwardSpaceButton":
       case "gamepadForwardCtrlButton":
       case "gamepadForwardEscapeButton":
@@ -6475,14 +6477,14 @@ app.whenReady().then(async () => {
     }
   });
 
-  // Curated keys the overlay may forward to the target game window. Mirrors the
-  // Python allowlist (overlay_handler.ALLOWED_FORWARD_KEYS); arbitrary keys are rejected.
-  const FORWARDABLE_KEYS = new Set(["enter", "space", "ctrl", "escape", "tab"]);
+  // Curated keys/actions the overlay may forward to the target game window. Mirrors the
+  // Python allowlist (overlay_handler.ALLOWED_FORWARD_KEYS); arbitrary values are rejected.
+  const FORWARDABLE_KEYS = new Set(["enter", "space", "ctrl", "escape", "tab", "mouseclick", "left-click"]);
 
   const forwardKeyToTargetWindow = (key) => {
     const normalizedKey = String(key || "").trim().toLowerCase();
     if (!FORWARDABLE_KEYS.has(normalizedKey)) {
-      console.warn(`[Gamepad] Refusing to forward unsupported key: ${key}`);
+      console.warn(`[Gamepad] Refusing to forward unsupported action: ${key}`);
       return;
     }
     if (!backend || !backend.connected) {

--- a/GSM_Overlay/settings.html
+++ b/GSM_Overlay/settings.html
@@ -1852,16 +1852,24 @@
         <input type="text" id="keyboardCancelKey" class="keyboard-binding-input" value="Escape" placeholder="Click and press a key" readonly />
       </label>
       <label>
-        <span class="label-text">
-          Forward Enter Button
+        <span class="hotkey-label">
+          <strong>Forward Enter Button</strong>
           <div class="hotkey-info">Send Enter to the current GSM target window</div>
         </span>
         <input type="text" id="gamepadForwardEnterButton" class="gamepad-binding-input" value="Disabled" placeholder="Click and press a controller combo" readonly />
         <input type="text" id="keyboardForwardEnterKey" class="keyboard-binding-input" value="Disabled" placeholder="Click and press a key" readonly />
       </label>
       <label>
-        <span class="label-text">
-          Forward Space Button
+        <span class="hotkey-label">
+          <strong>Forward Mouse Click Button</strong>
+          <div class="hotkey-info">Send a left mouse click to the current GSM target window</div>
+        </span>
+        <input type="text" id="gamepadForwardMouseClickButton" class="gamepad-binding-input" value="Disabled" placeholder="Click and press a controller combo" readonly />
+        <input type="text" id="keyboardForwardMouseClickKey" class="keyboard-binding-input" value="Disabled" placeholder="Click and press a key" readonly />
+      </label>
+      <label>
+        <span class="hotkey-label">
+          <strong>Forward Space Button</strong>
           <div class="hotkey-info">Send Space to the current GSM target window (advance text)</div>
         </span>
         <input type="text" id="gamepadForwardSpaceButton" class="gamepad-binding-input" value="Disabled" placeholder="Click and press a controller combo" readonly />
@@ -2291,6 +2299,7 @@
       gamepadConfirmButton: { settingKey: "gamepadConfirmButton", label: "Confirm Button", fallbackValue: 0 },
       gamepadCancelButton: { settingKey: "gamepadCancelButton", label: "Cancel Button", fallbackValue: 1 },
       gamepadForwardEnterButton: { settingKey: "gamepadForwardEnterButton", label: "Forward Enter Button", fallbackValue: -1 },
+      gamepadForwardMouseClickButton: { settingKey: "gamepadForwardMouseClickButton", label: "Forward Mouse Click Button", fallbackValue: -1 },
       gamepadForwardSpaceButton: { settingKey: "gamepadForwardSpaceButton", label: "Forward Space Button", fallbackValue: -1 },
       gamepadForwardCtrlButton: { settingKey: "gamepadForwardCtrlButton", label: "Forward Ctrl Button", fallbackValue: -1 },
       gamepadForwardEscapeButton: { settingKey: "gamepadForwardEscapeButton", label: "Forward Escape Button", fallbackValue: -1 },
@@ -2307,6 +2316,7 @@
       keyboardConfirmKey: { settingKey: "keyboardConfirmKey", label: "Keyboard Confirm Key", fallbackValue: "Enter" },
       keyboardCancelKey: { settingKey: "keyboardCancelKey", label: "Keyboard Cancel Key", fallbackValue: "Escape" },
       keyboardForwardEnterKey: { settingKey: "keyboardForwardEnterKey", label: "Keyboard Forward Enter Key", fallbackValue: null },
+      keyboardForwardMouseClickKey: { settingKey: "keyboardForwardMouseClickKey", label: "Keyboard Forward Mouse Click Key", fallbackValue: null },
       keyboardForwardSpaceKey: { settingKey: "keyboardForwardSpaceKey", label: "Keyboard Forward Space Key", fallbackValue: null },
       keyboardForwardCtrlKey: { settingKey: "keyboardForwardCtrlKey", label: "Keyboard Forward Ctrl Key", fallbackValue: null },
       keyboardForwardEscapeKey: { settingKey: "keyboardForwardEscapeKey", label: "Keyboard Forward Escape Key", fallbackValue: null },
@@ -2989,6 +2999,7 @@
         "gamepadConfirmButton",
         "gamepadCancelButton",
         "gamepadForwardEnterButton",
+        "gamepadForwardMouseClickButton",
         "gamepadForwardSpaceButton",
         "gamepadForwardCtrlButton",
         "gamepadForwardEscapeButton",
@@ -3341,6 +3352,7 @@
       createGamepadBindingSetting("gamepadConfirmButton"),
       createGamepadBindingSetting("gamepadCancelButton"),
       createGamepadBindingSetting("gamepadForwardEnterButton"),
+      createGamepadBindingSetting("gamepadForwardMouseClickButton"),
       createGamepadBindingSetting("gamepadForwardSpaceButton"),
       createGamepadBindingSetting("gamepadForwardCtrlButton"),
       createGamepadBindingSetting("gamepadForwardEscapeButton"),
@@ -3354,6 +3366,7 @@
       createKeyboardBindingSetting("keyboardConfirmKey"),
       createKeyboardBindingSetting("keyboardCancelKey"),
       createKeyboardBindingSetting("keyboardForwardEnterKey"),
+      createKeyboardBindingSetting("keyboardForwardMouseClickKey"),
       createKeyboardBindingSetting("keyboardForwardSpaceKey"),
       createKeyboardBindingSetting("keyboardForwardCtrlKey"),
       createKeyboardBindingSetting("keyboardForwardEscapeKey"),

--- a/GameSentenceMiner/util/platform/windows_window_monitor.py
+++ b/GameSentenceMiner/util/platform/windows_window_monitor.py
@@ -62,6 +62,12 @@ _FORWARD_KEY_ALIASES: Dict[str, str] = {
     "esc": "escape",
 }
 
+_FORWARD_MOUSE_CLICK_ALIASES = {"mouseclick", "left-click"}
+
+WM_LBUTTONDOWN = 0x0201
+WM_LBUTTONUP = 0x0202
+MK_LBUTTON = 0x0001
+
 WinEventProcType = ctypes.WINFUNCTYPE(
     None,
     wintypes.HANDLE,
@@ -1529,6 +1535,61 @@ class WindowsWindowStateMonitor(BaseWindowStateMonitor):
         name = _FORWARD_KEY_ALIASES.get(name, name)
         return name, _FORWARDABLE_KEYS.get(name)
 
+    @staticmethod
+    def _resolve_forward_mouse_click(key_name: Optional[str]) -> bool:
+        name = str(key_name or "").strip().lower()
+        return name in _FORWARD_MOUSE_CLICK_ALIASES
+
+    @staticmethod
+    def _pack_mouse_lparam(x: int, y: int) -> int:
+        return ((int(y) & 0xFFFF) << 16) | (int(x) & 0xFFFF)
+
+    def _resolve_left_click_client_point(self, hwnd: int) -> Optional[Tuple[int, int]]:
+        geometry = get_window_client_physical_geometry(hwnd)
+        if not geometry:
+            return None
+
+        left, top, width, height = geometry
+        if width <= 0 or height <= 0:
+            return None
+
+        click_x = width // 2
+        click_y = height // 2
+
+        try:
+            cursor_info = CURSORINFO()
+            cursor_info.cbSize = ctypes.sizeof(CURSORINFO)
+            if user32.GetCursorInfo(ctypes.byref(cursor_info)):
+                relative_x = int(cursor_info.ptScreenPos.x) - int(left)
+                relative_y = int(cursor_info.ptScreenPos.y) - int(top)
+                if 0 <= relative_x < width and 0 <= relative_y < height:
+                    click_x = relative_x
+                    click_y = relative_y
+        except Exception:
+            # If the cursor position cannot be resolved, keep the safe center fallback.
+            pass
+
+        return click_x, click_y
+
+    def _post_left_click_to_hwnd(self, hwnd: int) -> bool:
+        point = self._resolve_left_click_client_point(hwnd)
+        if not point:
+            return False
+
+        click_x, click_y = point
+        lparam = self._pack_mouse_lparam(click_x, click_y)
+
+        try:
+            logger.debug(f"Posting left click to HWND {hwnd} at client coordinates ({click_x}, {click_y})")
+            if not user32.PostMessageW(hwnd, WM_LBUTTONDOWN, MK_LBUTTON, lparam):
+                return False
+            if not user32.PostMessageW(hwnd, WM_LBUTTONUP, 0, lparam):
+                return False
+            return True
+        except Exception as e:
+            logger.exception(f"Error posting left click to HWND {hwnd}: {e}")
+            return False
+
     def _resolve_target_hwnd(self, target_pid: Optional[int] = None) -> Optional[int]:
         hwnd = self.target_hwnd
         requested_pid = int(target_pid or 0)
@@ -1699,9 +1760,12 @@ class WindowsWindowStateMonitor(BaseWindowStateMonitor):
     async def send_key_to_target_window(
         self, key_name: str, target_pid: Optional[int] = None, activate_window: bool = True
     ) -> bool:
-        """Forward one of the curated keys (see _FORWARDABLE_KEYS) to the target game window."""
+        """Forward one of the curated keys/actions (see _FORWARDABLE_KEYS) to the target game window."""
         if not is_windows():
             return False
+
+        if self._resolve_forward_mouse_click(key_name):
+            return await self.send_mouse_click_to_target_window(target_pid, activate_window)
 
         _, spec = self._resolve_forward_key(key_name)
         if not spec:
@@ -1728,6 +1792,28 @@ class WindowsWindowStateMonitor(BaseWindowStateMonitor):
             return self._send_key_with_fallbacks(vk, scan, extended)
         return self._post_key_to_hwnd(target_hwnd, vk, scan, extended)
 
+    async def send_mouse_click_to_target_window(
+        self, target_pid: Optional[int] = None, activate_window: bool = True
+    ) -> bool:
+        """Forward a single left mouse click to the target game window."""
+        if not is_windows():
+            return False
+
+        requested_pid = int(target_pid or 0)
+        target_hwnd = self._resolve_target_hwnd(requested_pid)
+        if not target_hwnd:
+            return False
+
+        self.target_hwnd = target_hwnd
+
+        if activate_window:
+            focused = await self.activate_target_window()
+            if not focused:
+                return False
+            await asyncio.sleep(0.03)
+
+        return self._post_left_click_to_hwnd(target_hwnd)
+
     def post_enter_to_target_window(self, target_pid: Optional[int] = None) -> bool:
         """Backward-compatible direct PostMessage path."""
         if not is_windows():
@@ -1739,3 +1825,14 @@ class WindowsWindowStateMonitor(BaseWindowStateMonitor):
             return False
 
         return self._post_enter_to_hwnd(hwnd)
+
+    def post_left_click_to_target_window(self, target_pid: Optional[int] = None) -> bool:
+        """Backward-compatible direct PostMessage path for a left click."""
+        if not is_windows():
+            return False
+
+        hwnd = self._resolve_target_hwnd(target_pid)
+        if not hwnd:
+            return False
+
+        return self._post_left_click_to_hwnd(hwnd)

--- a/GameSentenceMiner/web/overlay_handler.py
+++ b/GameSentenceMiner/web/overlay_handler.py
@@ -223,13 +223,24 @@ class OverlayRequestHandler:
         except Exception as e:
             logger.exception(f"Failed to restore focus to target window: {e}")
 
-    # Curated keys the overlay is allowed to forward to the target game window.
-    ALLOWED_FORWARD_KEYS = {"enter", "return", "space", "ctrl", "control", "escape", "esc", "tab"}
+    # Curated keys/actions the overlay is allowed to forward to the target game window.
+    ALLOWED_FORWARD_KEYS = {
+        "enter",
+        "return",
+        "space",
+        "ctrl",
+        "control",
+        "escape",
+        "esc",
+        "tab",
+        "mouseclick",
+        "left-click",
+    }
 
     async def handle_send_key_request(self, message: Optional[dict] = None):
         """
         Handle a key-forward request from the overlay.
-        Supports forwarding a curated set of keys (see ALLOWED_FORWARD_KEYS) to the
+        Supports forwarding a curated set of keys/actions (see ALLOWED_FORWARD_KEYS) to the
         target game window. The overlay never forwards arbitrary user-typed keys.
         """
         try:
@@ -243,13 +254,13 @@ class OverlayRequestHandler:
                 target_pid = 0
 
             if key_name not in self.ALLOWED_FORWARD_KEYS:
-                logger.warning(f"Unsupported overlay key request from {source}: {key_name}")
+                logger.warning(f"Unsupported overlay forward request from {source}: {key_name}")
                 return
 
             overlay_processor = get_overlay_processor()
             monitor = overlay_processor.window_monitor if overlay_processor else None
             if not monitor or not monitor.target_hwnd:
-                logger.debug(f"No target window available for overlay key request from {source}")
+                logger.debug(f"No target window available for overlay forward request from {source}")
                 return
 
             sent = await monitor.send_key_to_target_window(
@@ -258,7 +269,7 @@ class OverlayRequestHandler:
                 activate_window=activate_window,
             )
             if not sent:
-                logger.warning(f"Failed to send '{key_name}' key to target window (source={source})")
+                logger.warning(f"Failed to send '{key_name}' forward request to target window (source={source})")
         except Exception as e:
             logger.exception(f"Failed handling overlay key request: {e}")
 

--- a/electron-src/main/ui/gamepad-bindings.test.ts
+++ b/electron-src/main/ui/gamepad-bindings.test.ts
@@ -252,6 +252,57 @@ describe("legacy gamepad button bindings", () => {
     expect(calls).toEqual(["token-toggle", "mine"]);
   });
 
+  it("forwards the mouse click binding through the same IPC channel as curated keys", () => {
+    const handler = Object.create(GamepadHandler.prototype) as {
+      config: {
+        activationMode: string;
+        controllerEnabled: boolean;
+        forwardMouseClickButton: string;
+      };
+      buttonStates: Map<string, Record<number, boolean>>;
+      buttonBindings: Record<string, any>;
+      bindingContainsButton: (binding: any, buttonIndex: number) => boolean;
+      isButtonBindingHeld: (binding: any, device: string) => boolean;
+      matchesButtonBindingDown: (binding: any, device: string, buttonIndex: number) => boolean;
+      refreshButtonBindings: () => void;
+      onButtonDown: (buttonIndex: number, device: string) => void;
+      getIpcRenderer: () => { send: (...args: any[]) => void } | null;
+      forwardMouseClickToTargetWindow: () => void;
+    };
+
+    handler.config = {
+      activationMode: "modifier",
+      controllerEnabled: true,
+      forwardMouseClickButton: "Back/Select/View"
+    };
+    handler.buttonStates = new Map([["pad-1", { 8: true }]]);
+    handler.bindingContainsButton = GamepadHandler.prototype.bindingContainsButton;
+    handler.isButtonBindingHeld = GamepadHandler.prototype.isButtonBindingHeld;
+    handler.matchesButtonBindingDown = GamepadHandler.prototype.matchesButtonBindingDown;
+    handler.refreshButtonBindings = GamepadHandler.prototype.refreshButtonBindings;
+    handler.onButtonDown = GamepadHandler.prototype.onButtonDown;
+    handler.forwardMouseClickToTargetWindow = GamepadHandler.prototype.forwardMouseClickToTargetWindow;
+
+    const calls: Array<[string, ...any[]]> = [];
+    handler.getIpcRenderer = () => ({
+      send: (...args: any[]) => {
+        calls.push(args as [string, ...any[]]);
+      }
+    });
+
+    handler.refreshButtonBindings();
+
+    expect(handler.buttonBindings.forwardMouseClickButton).toMatchObject({
+      buttons: [8],
+      disabled: false,
+      label: "Back"
+    });
+
+    handler.onButtonDown(8, "pad-1");
+
+    expect(calls).toEqual([["gamepad-forward-key", "mouseclick"]]);
+  });
+
   it("preserves confirm behavior when mine and confirm share the default A button", () => {
     const handler = Object.create(GamepadHandler.prototype) as {
       config: {

--- a/electron-src/main/ui/overlay-settings-keyboard-bindings.test.ts
+++ b/electron-src/main/ui/overlay-settings-keyboard-bindings.test.ts
@@ -16,9 +16,17 @@ function nextTick(delay = 0) {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
-function loadOverlaySettingsPage() {
+function loadOverlaySettingsPage(options: {
+  gamepads?: Array<any>;
+  setIntervalImpl?: (callback: () => void, delay?: number) => number;
+  clearIntervalImpl?: (id: number) => void;
+} = {}) {
   const html = fs.readFileSync(
     path.resolve(process.cwd(), "GSM_Overlay/settings.html"),
+    "utf8"
+  );
+  const manualModeCardSource = fs.readFileSync(
+    path.resolve(process.cwd(), "GSM_Overlay/components/manual-mode-card.js"),
     "utf8"
   );
   const sent: Array<{ channel: string; payload: IpcPayload }> = [];
@@ -67,10 +75,11 @@ function loadOverlaySettingsPage() {
       };
       window.process = { platform: "win32" };
       window.WebSocket = FakeWebSocket;
-      window.setInterval = () => 0;
-      window.clearInterval = () => {};
+      window.eval(manualModeCardSource);
+      window.setInterval = options.setIntervalImpl ?? (() => 0);
+      window.clearInterval = options.clearIntervalImpl ?? (() => {});
       window.console = { ...window.console, log: () => {} };
-      window.navigator.getGamepads = () => [];
+      window.navigator.getGamepads = () => options.gamepads ?? [];
       window.open = () => null;
     }
   });
@@ -121,6 +130,59 @@ describe("overlay settings keyboard binding capture", () => {
       const settingChangesAfter = page.sent.filter((entry) => entry.channel === "setting-changed").length;
       expect(input.value).toBe("Disabled");
       expect(settingChangesAfter).toBe(settingChangesBefore);
+    } finally {
+      page.dom.window.close();
+    }
+  });
+
+  it("persists a mouse-click gamepad binding through the setting-changed channel", async () => {
+    const intervals: Array<() => void> = [];
+    const gamepads = [
+      {
+        index: 0,
+        id: "Test Controller",
+        buttons: [{ pressed: false, value: 0 }]
+      }
+    ];
+    const page = loadOverlaySettingsPage({
+      gamepads,
+      setIntervalImpl: (callback: () => void) => {
+        intervals.push(callback);
+        return intervals.length;
+      },
+      clearIntervalImpl: () => {}
+    });
+
+    try {
+      await nextTick(20);
+      const input = page.dom.window.document.getElementById("gamepadForwardMouseClickButton") as HTMLInputElement;
+
+      input.focus();
+      await nextTick();
+      expect(intervals.length).toBeGreaterThan(0);
+      const captureInterval = intervals.at(-1)!;
+
+      gamepads[0] = {
+        index: 0,
+        id: "Test Controller",
+        buttons: [{ pressed: true, value: 1 }]
+      };
+      captureInterval();
+      await nextTick();
+      expect(input.value).toBe("A");
+
+      gamepads[0] = {
+        index: 0,
+        id: "Test Controller",
+        buttons: [{ pressed: false, value: 0 }]
+      };
+      captureInterval();
+      await nextTick();
+
+      expect(page.sent.findLast((entry) => entry.channel === "setting-changed")?.payload).toEqual({
+        key: "gamepadForwardMouseClickButton",
+        value: "A"
+      });
     } finally {
       page.dom.window.close();
     }

--- a/tests/util/platform/test_window_state_monitor_focus.py
+++ b/tests/util/platform/test_window_state_monitor_focus.py
@@ -410,6 +410,27 @@ def test_send_key_to_target_window_injects_curated_key(monkeypatch):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_send_key_to_target_window_injects_mouse_click_via_postmessage(monkeypatch):
+    monitor = window_state_monitor.WindowStateMonitor()
+    monitor.target_hwnd = 20
+
+    monkeypatch.setattr(_wwm, "is_windows", lambda: True)
+
+    async def fake_activate():
+        return True
+
+    activation_calls = []
+    click_calls = []
+
+    monkeypatch.setattr(monitor, "activate_target_window", lambda: activation_calls.append(True) or fake_activate())
+    monkeypatch.setattr(monitor, "_post_left_click_to_hwnd", lambda hwnd: click_calls.append(hwnd) or True)
+
+    assert asyncio.run(monitor.send_key_to_target_window("mouseclick", activate_window=True)) is True
+    assert activation_calls == [True]
+    assert click_calls == [20]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
 def test_send_key_to_target_window_rejects_unknown_key(monkeypatch):
     monitor = window_state_monitor.WindowStateMonitor()
     monitor.target_hwnd = 20

--- a/tests/web/test_overlay_handler.py
+++ b/tests/web/test_overlay_handler.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from GameSentenceMiner.web import overlay_handler as overlay_handler_module
 
 
@@ -79,3 +81,64 @@ def test_overlay_recycled_indicator_setting_rejects_unknown_key(monkeypatch):
 
     assert current_config.overlay.check_previous_lines_for_recycled_indicator is False
     assert saved_configs == []
+
+
+@pytest.mark.parametrize("key_name", ["mouseclick", "left-click"])
+def test_overlay_forward_mouse_click_request_is_allowlisted(monkeypatch, key_name):
+    calls = []
+
+    async def fake_send_key_to_target_window(key, target_pid=None, activate_window=True):
+        calls.append((key, target_pid, activate_window))
+        return True
+
+    fake_monitor = SimpleNamespace(
+        target_hwnd=123,
+        send_key_to_target_window=fake_send_key_to_target_window,
+    )
+    fake_overlay_processor = SimpleNamespace(window_monitor=fake_monitor)
+    handler = overlay_handler_module.OverlayRequestHandler()
+
+    monkeypatch.setattr(overlay_handler_module, "get_overlay_processor", lambda: fake_overlay_processor)
+
+    asyncio.run(
+        handler.handle_send_key_request(
+            {
+                "key": key_name,
+                "source": "gamepad",
+                "activateWindow": False,
+                "targetPid": "42",
+            }
+        )
+    )
+
+    assert calls == [(key_name, 42, False)]
+
+
+def test_overlay_forward_mouse_click_rejects_unknown_key(monkeypatch):
+    calls = []
+
+    async def fake_send_key_to_target_window(key, target_pid=None, activate_window=True):
+        calls.append((key, target_pid, activate_window))
+        return True
+
+    fake_monitor = SimpleNamespace(
+        target_hwnd=123,
+        send_key_to_target_window=fake_send_key_to_target_window,
+    )
+    fake_overlay_processor = SimpleNamespace(window_monitor=fake_monitor)
+    handler = overlay_handler_module.OverlayRequestHandler()
+
+    monkeypatch.setattr(overlay_handler_module, "get_overlay_processor", lambda: fake_overlay_processor)
+
+    asyncio.run(
+        handler.handle_send_key_request(
+            {
+                "key": "f13",
+                "source": "gamepad",
+                "activateWindow": False,
+                "targetPid": "42",
+            }
+        )
+    )
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- Adds a disabled-by-default controller/keyboard "Forward Mouse Click" bind in the GSM overlay controller tab.
- Forwarding uses a curated allowlist end-to-end (`mouseclick` / `left-click`) and posts a single left click to the target window on Windows.

## How to use
- In Overlay Settings > Controller, set "Forward Mouse Click Button" or its keyboard counterpart.
- The bind is disabled by default, so existing controller behavior is unchanged until configured.

## Verification
- `npm run build:main`
- `uv run --active pytest tests/web/test_overlay_handler.py tests/util/platform/test_window_state_monitor_focus.py`
- `npm run test:ts -- electron-src/main/ui/gamepad-bindings.test.ts electron-src/main/ui/overlay-settings-keyboard-bindings.test.ts` (passes except for one pre-existing failure in `snaps virtual mouse points to the nearest selectable block`)