### PR TITLE
Add more Python locking for safety

### DIFF
--- a/GameSentenceMiner/util/config/configuration.py
+++ b/GameSentenceMiner/util/config/configuration.py
@@ -2399,41 +2399,44 @@ def load_config():
 
 
 config_instance: Config = None
+# Guards swaps/mutations of config_instance against concurrent get_config() reads. RLock for re-entrancy.
+_config_lock = threading.RLock()
 
 
 def get_config():
     global config_instance
-    if config_instance is None:
-        config_instance = load_config()
-
-    return config_instance.get_config()
+    with _config_lock:
+        if config_instance is None:
+            config_instance = load_config()
+        return config_instance.get_config()
 
 
 def get_overlay_config():
     global config_instance
-    if config_instance is None:
-        config_instance = load_config()
-    return config_instance.overlay
-    # global config_instance
-    # if config_instance is None:
-    #     config_instance = load_config()
-    # return config_instance.overlay
+    with _config_lock:
+        if config_instance is None:
+            config_instance = load_config()
+        return config_instance.overlay
 
 
 def reload_config():
     global config_instance
-    config_instance = load_config()
+    new_config = load_config()
+    with _config_lock:
+        config_instance = new_config
 
 
 def get_stats_config():
     global config_instance
-    if config_instance is None:
-        config_instance = load_config()
-    return config_instance.stats
+    with _config_lock:
+        if config_instance is None:
+            config_instance = load_config()
+        return config_instance.stats
 
 
 def get_master_config():
-    return config_instance
+    with _config_lock:
+        return config_instance
 
 
 def save_full_config(config):
@@ -2445,19 +2448,22 @@ def save_full_config(config):
 
 def save_current_config(config):
     global config_instance
-    config_instance.set_config_for_profile(config_instance.current_profile, config)
+    with _config_lock:
+        config_instance.set_config_for_profile(config_instance.current_profile, config)
     save_full_config(config_instance)
 
 
 def save_stats_config(stats_config):
     global config_instance
-    config_instance.stats = stats_config
+    with _config_lock:
+        config_instance.stats = stats_config
     save_full_config(config_instance)
 
 
 def switch_profile_and_save(profile_name):
     global config_instance
-    config_instance.current_profile = profile_name
+    with _config_lock:
+        config_instance.current_profile = profile_name
     save_full_config(config_instance)
     return config_instance.get_config()
 

--- a/GameSentenceMiner/util/database/db.py
+++ b/GameSentenceMiner/util/database/db.py
@@ -206,16 +206,18 @@ class SQLiteDB:
             return cur
 
     def fetchall(self, query: str, params: Union[Tuple, Dict] = ()) -> List[Tuple]:
-        conn = self._get_connection()
-        cur = conn.cursor()
-        cur.execute(query, params)
-        return cur.fetchall()
+        with self._lock:
+            conn = self._get_connection()
+            cur = conn.cursor()
+            cur.execute(query, params)
+            return cur.fetchall()
 
     def fetchone(self, query: str, params: Union[Tuple, Dict] = ()) -> Optional[Tuple]:
-        conn = self._get_connection()
-        cur = conn.cursor()
-        cur.execute(query, params)
-        return cur.fetchone()
+        with self._lock:
+            conn = self._get_connection()
+            cur = conn.cursor()
+            cur.execute(query, params)
+            return cur.fetchone()
 
     def create_table(self, table_sql: str):
         if self.read_only:
@@ -306,9 +308,10 @@ class SQLiteDBTable:
         return cls.from_row(row) if row else None
 
     @classmethod
-    def from_row(cls: Type[T], row: Tuple, clean_columns: list = []) -> T:
+    def from_row(cls: Type[T], row: Tuple, clean_columns: Optional[list] = None) -> T:
         if not row:
             return None
+        clean_columns = clean_columns or []
         obj = cls()
 
         try:


### PR DESCRIPTION
Some targeted correctness/locking fixes (and one mutable default argument fix).

## What changed
- `db.py`: `fetchall()`/`fetchone()` now take `self._lock` like the rest of the class did (they were the odd ones out).
- `configuration.py`: the module-global `config_instance` was being swapped with no lock while other threads read it via `get_config()`. Added an `RLock` and guarded the reads + the swap, keeping the slow file I/O *outside* the critical section to avoid deadlocks.
- `db.py`: mutable default arg `clean_columns: list = []` → `None` sentinel.

## Why
The config swap race and the unlocked reads are real thread-safety holes given the asyncio + Qt + worker-thread setup.
