### PR TITLE
Eliminate some per-frame OCR overhead

### DIFF
--- a/GameSentenceMiner/owocr/owocr/ocr_runtime.py
+++ b/GameSentenceMiner/owocr/owocr/ocr_runtime.py
@@ -609,10 +609,7 @@ class ClipboardThread(threading.Thread):
         if None in (img1, img2):
             return img1 == img2
 
-        img1 = np.array(img1)
-        img2 = np.array(img2)
-
-        return (img1.shape == img2.shape) and (img1 == img2).all()
+        return are_images_identical(img1, img2)
 
     def normalize_macos_clipboard(self, img):
         if _load_macos_capture_dependencies() is None:

--- a/GameSentenceMiner/util/config/electron_config.py
+++ b/GameSentenceMiner/util/config/electron_config.py
@@ -220,7 +220,7 @@ class Store:
                 return _clone(self.data)
             return _deep_merge_defaults(self.defaults, raw_data)
 
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str, default: Any = None, *, copy: bool = True) -> Any:
         keys = key.split(".") if key else []
         with self._lock:
             value: Any = self.data
@@ -229,7 +229,7 @@ class Store:
                     value = value[current_key]
                 else:
                     return default
-            return _clone(value)
+            return _clone(value) if copy else value
 
     def set(self, key: str, value: Any) -> bool:
         keys = key.split(".") if key else []
@@ -289,6 +289,11 @@ def _get_ocr_value(key: str, default: Any = None) -> Any:
     return _get_ocr_config().get(key, default)
 
 
+def _get_ocr_value_readonly(key: str, default: Any = None) -> Any:
+    """Read a single OCR scalar without deepcopying the whole OCR dict."""
+    return electron_store.get(f"OCR.{key}", default, copy=False)
+
+
 def _get_ocr_int_value(
     key: str,
     default: int,
@@ -309,7 +314,7 @@ def _get_ocr_int_value(
 
 
 def _is_advanced_mode() -> bool:
-    return bool(_get_ocr_value("advancedMode", False))
+    return bool(_get_ocr_value_readonly("advancedMode", False))
 
 
 def _get_keep_newline_key_for_source(source: str | None = None) -> str:
@@ -371,7 +376,7 @@ def _get_basic_ocr2_engine(ocr_config: Dict[str, Any]) -> str:
 def get_ocr_two_pass_ocr() -> bool:
     if not _is_advanced_mode():
         return True
-    return bool(_get_ocr_value("twoPassOCR", True))
+    return bool(_get_ocr_value_readonly("twoPassOCR", True))
 
 
 def get_ocr_optimize_second_scan() -> bool:
@@ -403,7 +408,7 @@ def get_ocr_window_name() -> str:
 
 
 def get_ocr_language() -> str:
-    return str(_get_ocr_value("language", "ja") or "ja")
+    return str(_get_ocr_value_readonly("language", "ja") or "ja")
 
 
 def get_ocr_ocr_screenshots() -> bool:
@@ -414,7 +419,7 @@ def get_ocr_ocr_screenshots() -> bool:
 
 def get_ocr_furigana_filter_sensitivity() -> int:
     try:
-        return int(_get_ocr_value("furigana_filter_sensitivity", 0))
+        return int(_get_ocr_value_readonly("furigana_filter_sensitivity", 0))
     except (TypeError, ValueError):
         return 0
 
@@ -461,11 +466,10 @@ def get_ocr_send_to_clipboard(source: str | None = None) -> bool:
 
 
 def get_ocr_scan_rate() -> float:
-    ocr_config = _get_ocr_config()
-    scan_rate = ocr_config.get("scanRate")
+    scan_rate = _get_ocr_value_readonly("scanRate", None)
 
     if scan_rate is None and not _is_advanced_mode():
-        scan_rate = ocr_config.get("scanRate_basic", 0.5)
+        scan_rate = _get_ocr_value_readonly("scanRate_basic", 0.5)
 
     try:
         return float(scan_rate)
@@ -495,12 +499,12 @@ def get_ocr_base_scale() -> float:
 
 
 def get_ocr_keep_newline(source: str | None = None) -> bool:
-    explicit_value = _get_ocr_value(_get_keep_newline_key_for_source(source), None)
+    explicit_value = _get_ocr_value_readonly(_get_keep_newline_key_for_source(source), None)
     if isinstance(explicit_value, bool):
         return explicit_value
     if not _is_advanced_mode():
         return True
-    return bool(_get_ocr_value("keep_newline", False))
+    return bool(_get_ocr_value_readonly("keep_newline", False))
 
 
 def get_ocr_duplicate_similarity_threshold() -> int:

--- a/GameSentenceMiner/util/gsm_utils.py
+++ b/GameSentenceMiner/util/gsm_utils.py
@@ -174,17 +174,36 @@ def isascii(s: str):
             return False
 
 
-def do_text_replacements(text, replacements_json):
-    if not text:
-        return text
+# Cache parsed replacements + compiled regexes, keyed by file path and mtime.
+_text_replacements_cache: dict = {}
 
-    replacements = {}
-    if os.path.exists(replacements_json):
+
+def _load_text_replacements(replacements_json):
+    """Return (enabled, compiled_ops) for the replacements file, cached by mtime.
+
+    compiled_ops is a list of (kind, payload, replacement):
+      - "re": compiled regex (re: prefix)
+      - "word": compiled whole-word ascii regex
+      - "literal": plain str.replace search string
+    """
+    try:
+        mtime = os.path.getmtime(replacements_json)
+    except OSError:
+        return False, []
+
+    cached = _text_replacements_cache.get(replacements_json)
+    if cached is not None and cached[0] == mtime:
+        return cached[1], cached[2]
+
+    try:
         with open(replacements_json, "r", encoding="utf-8") as f:
-            replacements.update(json.load(f))
+            replacements = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False, []
 
-    if replacements.get("enabled", False):
-        orig_text = text
+    enabled = bool(replacements.get("enabled", False))
+    compiled_ops = []
+    if enabled:
         filters = replacements.get("args", {}).get("replacements", {})
         for fil, replacement in filters.items():
             if not fil:
@@ -192,14 +211,31 @@ def do_text_replacements(text, replacements_json):
             if fil.startswith("re:"):
                 pattern = fil[3:]
                 try:
-                    text = re.sub(pattern, replacement, text)
-                except Exception:
+                    compiled_ops.append(("re", re.compile(pattern), replacement))
+                except re.error:
                     logger.error(f"Invalid regex pattern: {pattern}")
                     continue
             if isascii(fil):
-                text = re.sub(r"\b{}\b".format(re.escape(fil)), replacement, text)
+                compiled_ops.append(("word", re.compile(r"\b{}\b".format(re.escape(fil))), replacement))
             else:
-                text = text.replace(fil, replacement)
+                compiled_ops.append(("literal", fil, replacement))
+
+    _text_replacements_cache[replacements_json] = (mtime, enabled, compiled_ops)
+    return enabled, compiled_ops
+
+
+def do_text_replacements(text, replacements_json):
+    if not text:
+        return text
+
+    enabled, compiled_ops = _load_text_replacements(replacements_json)
+    if enabled:
+        orig_text = text
+        for kind, payload, replacement in compiled_ops:
+            if kind == "literal":
+                text = text.replace(payload, replacement)
+            else:
+                text = payload.sub(replacement, text)
         if text != orig_text:
             logger.info(f"Text replaced: '{orig_text}' -> '{text}' using replacements.")
     return text


### PR DESCRIPTION
## What changed
- `electron_config.py`: `Store.get()` was doing a full `copy.deepcopy` of the OCR config under a lock on *every* getter. Added an opt-in `copy=False` and a read-only scalar accessor, and switched the per-frame scalar getters to use it. Mutable-returning getters keep their deepcopy.
- `gsm_utils.py`: `do_text_replacements` no longer reads + JSON-parses the replacements file and recompiles regexes on every call — it caches by file mtime and precompiles the patterns.
- `ocr_runtime.py`: `ClipboardThread.are_images_identical` now reuses the existing `are_images_identical` with faster early False return.

## Why
These ran several times per frame; the deepcopy in particular was pure waste since the getters return scalars.

