### PR TITLE
Preserve target-word HTML during translation prefetch

### DIFF
--- a/GameSentenceMiner/anki.py
+++ b/GameSentenceMiner/anki.py
@@ -3434,11 +3434,12 @@ def queue_card_for_processing(
         timing_context.mark_queued()
     translation_future = None
     if get_config().ai.add_to_anki:
-        sentence_to_translate = last_mined_line.text if last_mined_line else ""
         if lines:
-            selected_text = combine_dialogue([line.text for line in lines if line and line.text])
-            if selected_text:
-                sentence_to_translate = "".join(selected_text)
+            sentence_to_translate = _build_selected_lines_sentence(last_card, lines)
+        elif last_mined_line:
+            sentence_to_translate = _sentence_for_current_card_html(last_card, last_mined_line.text)
+        else:
+            sentence_to_translate = ""
         translation_future = translation_prefetch_executor.submit(
             run_anki_card_timed,
             timing_context,

--- a/tests/test_anki.py
+++ b/tests/test_anki.py
@@ -837,6 +837,37 @@ def test_queue_card_for_processing_translates_matched_line_instead_of_raw_ocr_bl
     assert anki.card_queue[-1][7] is translation_future
 
 
+def test_queue_card_for_processing_preserves_target_word_html_for_translation(monkeypatch):
+    cfg = _base_config()
+    cfg.ai.add_to_anki = True
+    monkeypatch.setattr(anki, "get_config", lambda: cfg)
+    monkeypatch.setattr(anki.obs, "save_replay_buffer", lambda: None)
+    monkeypatch.setattr(
+        anki,
+        "_get_texthooking_page_module",
+        lambda: SimpleNamespace(reset_checked_lines=lambda: None),
+    )
+
+    submitted = []
+
+    class RecordingExecutor:
+        def submit(self, func, *args):
+            submitted.append((func, args))
+            return object()
+
+    monkeypatch.setattr(anki, "translation_prefetch_executor", RecordingExecutor())
+
+    line = SimpleNamespace(id="line-2", text="お前が感傷的になった")
+    card = SimpleNamespace(
+        noteId=42,
+        get_field=lambda field: "お前が<b>感傷的</b>になった" if field == cfg.anki.sentence_field else "感傷的",
+    )
+
+    anki.queue_card_for_processing(card, [], line)
+
+    assert submitted[0][1][3] == "お前が<b>感傷的</b>になった"
+
+
 def test_queue_card_for_processing_prefetches_multiple_plain_selected_lines(monkeypatch):
     cfg = _base_config()
     cfg.ai.add_to_anki = True


### PR DESCRIPTION
Closes #521

Translation prefetch now builds the same card-aware sentence used by the update path, preserving target-word HTML before the prompt is sent. This restores translated-word emphasis on the first card while retaining the matched-line and multi-line behavior.

Tested with `python -m pytest tests/test_anki.py -q` (90 passed) and Ruff check/format on both changed files.
