### PR TITLE
Add configurable Today stats rollover hour

### DIFF
--- a/GameSentenceMiner/util/config/configuration.py
+++ b/GameSentenceMiner/util/config/configuration.py
@@ -1755,6 +1755,7 @@ class ProfileConfig:
 @dataclass
 class StatsConfig:
     session_gap_seconds: int = 1800
+    day_rollover_hour: int = 4  # Hour (0-23) when a new day starts for the Today stats card
     reading_time_adaptive_v2: bool = True  # v2: cap reading time by conservative session median speed
     streak_requirement_hours: float = 0.01  # 1 second required per day to keep your streak by default
     reading_hours_target: int = 1500  # Target reading hours based on TMW N1 achievement data

--- a/GameSentenceMiner/web/database_api.py
+++ b/GameSentenceMiner/web/database_api.py
@@ -1224,6 +1224,9 @@ def register_database_api_routes(app):
               properties:
                 session_gap_seconds:
                   type: integer
+                day_rollover_hour:
+                  type: integer
+                  description: Hour when a new day starts for the Today stats card (0-23)
                 streak_requirement_hours:
                   type: number
                 reading_hours_target:
@@ -1254,6 +1257,7 @@ def register_database_api_routes(app):
             return jsonify(
                 {
                     "session_gap_seconds": config.session_gap_seconds,
+                    "day_rollover_hour": getattr(config, "day_rollover_hour", 4),
                     "streak_requirement_hours": config.streak_requirement_hours,
                     "reading_hours_target": config.reading_hours_target,
                     "character_count_target": config.character_count_target,
@@ -1313,6 +1317,9 @@ def register_database_api_routes(app):
                 session_gap_seconds:
                   type: integer
                   description: Session gap in seconds (0-7200)
+                day_rollover_hour:
+                  type: integer
+                  description: Hour when a new day starts for the Today stats card (0-23)
                 streak_requirement_hours:
                   type: number
                   description: Hours required for streak (0.01-24)
@@ -1354,6 +1361,7 @@ def register_database_api_routes(app):
                 return jsonify({"error": "No data provided"}), 400
 
             session_gap = data.get("session_gap_seconds")
+            day_rollover_hour = data.get("day_rollover_hour")
             streak_requirement = data.get("streak_requirement_hours")
             reading_hours_target = data.get("reading_hours_target")
             character_count_target = data.get("character_count_target")
@@ -1393,6 +1401,15 @@ def register_database_api_routes(app):
                     settings_to_update["session_gap_seconds"] = session_gap
                 except (ValueError, TypeError):
                     return jsonify({"error": "Session gap must be a valid integer"}), 400
+
+            if day_rollover_hour is not None:
+                try:
+                    day_rollover_hour = int(day_rollover_hour)
+                    if day_rollover_hour < 0 or day_rollover_hour > 23:
+                        return jsonify({"error": "Day rollover hour must be between 0 and 23"}), 400
+                    settings_to_update["day_rollover_hour"] = day_rollover_hour
+                except (ValueError, TypeError):
+                    return jsonify({"error": "Day rollover hour must be a valid integer"}), 400
 
             if streak_requirement is not None:
                 try:
@@ -1615,6 +1632,8 @@ def register_database_api_routes(app):
 
             if "session_gap_seconds" in settings_to_update:
                 config.session_gap_seconds = settings_to_update["session_gap_seconds"]
+            if "day_rollover_hour" in settings_to_update:
+                config.day_rollover_hour = settings_to_update["day_rollover_hour"]
             if "streak_requirement_hours" in settings_to_update:
                 config.streak_requirement_hours = settings_to_update["streak_requirement_hours"]
             if "reading_hours_target" in settings_to_update:

--- a/GameSentenceMiner/web/static/js/shared.js
+++ b/GameSentenceMiner/web/static/js/shared.js
@@ -219,6 +219,7 @@ function syncStatsConfigFromSettings(settings) {
 
     const keyMap = {
         session_gap_seconds: 'sessionGapSeconds',
+        day_rollover_hour: 'dayRolloverHour',
         streak_requirement_hours: 'streakRequirementHours',
         reading_hours_target: 'readingHoursTarget',
         character_count_target: 'characterCountTarget',
@@ -263,6 +264,7 @@ class SettingsManager {
         
         // Optional elements that may not exist on all pages
         this.sessionGapInput = document.getElementById('sessionGap');
+        this.dayRolloverHourInput = document.getElementById('dayRolloverHour');
         this.streakRequirementInput = document.getElementById('streakRequirement');
         this.readingHoursTargetInput = document.getElementById('readingHoursTarget');
         this.characterCountTargetInput = document.getElementById('characterCountTarget');
@@ -339,6 +341,7 @@ class SettingsManager {
         // Clear messages when user starts typing
         [
             this.sessionGapInput,
+            this.dayRolloverHourInput,
             this.streakRequirementInput,
             this.readingHoursTargetInput,
             this.characterCountTargetInput,
@@ -405,6 +408,9 @@ class SettingsManager {
         if (this.sessionGapInput) {
             this.sessionGapInput.value = settings.session_gap_seconds;
         }
+        if (this.dayRolloverHourInput) {
+            this.dayRolloverHourInput.value = settings.day_rollover_hour ?? 4;
+        }
         if (this.streakRequirementInput) {
             this.streakRequirementInput.value = settings.streak_requirement_hours || 1;
         }
@@ -463,6 +469,15 @@ class SettingsManager {
                     return;
                 }
                 settings.session_gap_seconds = sessionGap;
+            }
+
+            if (this.dayRolloverHourInput) {
+                const dayRolloverHour = parseInt(this.dayRolloverHourInput.value);
+                if (isNaN(dayRolloverHour) || dayRolloverHour < 0 || dayRolloverHour > 23) {
+                    this.showError('Day rollover hour must be between 0 and 23');
+                    return;
+                }
+                settings.day_rollover_hour = dayRolloverHour;
             }
             
             if (this.streakRequirementInput) {

--- a/GameSentenceMiner/web/stats_api.py
+++ b/GameSentenceMiner/web/stats_api.py
@@ -2194,21 +2194,19 @@ def register_stats_api_routes(app):
             # Get configuration
             config = get_stats_config()
             session_gap_seconds = config.session_gap_seconds
+            rollover_hour = max(0, min(23, int(getattr(config, "day_rollover_hour", 4))))
             minimum_session_length = 0  # 5 minutes
 
-            # Get today's date range (with cheeky 4AM logic)
+            # Get today's date range using the configured rollover hour.
             now = datetime.datetime.now()
             today = datetime.date.today()
 
-            if now.hour < 4:
-                # If before 4AM, we want to show "Yesterday + Today's early hours"
-                # So we fetch from Yesterday 04:00 to Today 04:00
-                yesterday = today - datetime.timedelta(days=1, hours=4)
-                today_start = datetime.datetime.combine(yesterday, datetime.time(4, 0)).timestamp()
-                today_end = datetime.datetime.combine(today, datetime.time(4, 0)).timestamp()
+            if now.hour < rollover_hour:
+                yesterday = today - datetime.timedelta(days=1)
+                today_start = datetime.datetime.combine(yesterday, datetime.time(rollover_hour, 0)).timestamp()
+                today_end = datetime.datetime.combine(today, datetime.time(rollover_hour, 0)).timestamp()
             else:
-                # Normal behavior: Today 04:00 to Today 23:59:59
-                today_start = datetime.datetime.combine(today, datetime.time(4, 0)).timestamp()
+                today_start = datetime.datetime.combine(today, datetime.time(rollover_hour, 0)).timestamp()
                 today_end = datetime.datetime.combine(today, datetime.time.max).timestamp()
 
             # Query all game lines for today using lightweight stats records.

--- a/GameSentenceMiner/web/templates/components/settings-modal.html
+++ b/GameSentenceMiner/web/templates/components/settings-modal.html
@@ -63,6 +63,20 @@
                 </div>
 
                 <div style="margin-bottom: 20px;">
+                    <label for="dayRolloverHour"
+                        style="display: block; font-weight: 600; margin-bottom: 8px; color: var(--text-primary);">
+                        Day Rollover Hour
+                    </label>
+                    <input type="number" id="dayRolloverHour" name="day_rollover_hour" min="0" max="23" step="1"
+                        style="padding: 10px; border: 1px solid var(--border-color); border-radius: 5px; background: var(--bg-tertiary); color: var(--text-primary); font-size: 14px;"
+                        placeholder="4">
+                    <small
+                        style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                        Hour (0-23) when the Today card starts a new day. Earlier activity counts toward the previous day. 0 is midnight; the default is 4 (4 AM).
+                    </small>
+                </div>
+
+                <div style="margin-bottom: 20px;">
                     <!-- <label for="regex_out_punctuation" style="display: block; font-weight: 600; margin-bottom: 8px; color: var(--text-primary);">
                         Ignore Punctuation (Regex)
                     </label>

--- a/tests/util/config/test_default_config_changes.py
+++ b/tests/util/config/test_default_config_changes.py
@@ -18,6 +18,10 @@ def test_tadoku_stats_defaults_are_safe_and_cleanup_daily_sync():
     assert stats.tadoku_daily_sync_deduplicate is True
 
 
+def test_stats_day_rollover_defaults_to_four_am():
+    assert StatsConfig().day_rollover_hour == 4
+
+
 def test_obs_replay_buffer_duration_defaults_and_clamps():
     assert OBS().replay_buffer_enabled is True
     assert OBS().replay_buffer_duration_seconds == 300

--- a/tests/web/test_stats_api_extra_routes.py
+++ b/tests/web/test_stats_api_extra_routes.py
@@ -211,19 +211,25 @@ class TestTodayStatsRoute:
         def now(cls, tz=None):
             return cls(2026, 3, 12, 12, 0, 0, tzinfo=tz)
 
-    def _patch_time(self, monkeypatch):
+    class _BeforeSixDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 3, 12, 5, 0, 0, tzinfo=tz)
+
+    def _patch_time(self, monkeypatch, *, day_rollover_hour=4, datetime_type=None):
         monkeypatch.setattr(
             "GameSentenceMiner.web.stats_api.datetime.date",
             self._FixedDate,
         )
         monkeypatch.setattr(
             "GameSentenceMiner.web.stats_api.datetime.datetime",
-            self._FixedDateTime,
+            datetime_type or self._FixedDateTime,
         )
         monkeypatch.setattr(
             "GameSentenceMiner.web.stats_api.get_stats_config",
             lambda: SimpleNamespace(
                 session_gap_seconds=5000,
+                day_rollover_hour=day_rollover_hour,
             ),
         )
 
@@ -279,6 +285,51 @@ class TestTodayStatsRoute:
         assert session["totalChars"] == 6
         assert session["totalSeconds"] == 15.0
         assert session["charsPerHour"] == 1440
+
+    def test_today_stats_uses_previous_day_when_before_configured_rollover(self, client, monkeypatch):
+        self._patch_time(
+            monkeypatch,
+            day_rollover_hour=6,
+            datetime_type=self._BeforeSixDateTime,
+        )
+        lines = [
+            ("before-start", "excluded", datetime.datetime(2026, 3, 11, 5, 59).timestamp()),
+            ("at-start", "a", datetime.datetime(2026, 3, 11, 6, 0).timestamp()),
+            ("before-end", "bc", datetime.datetime(2026, 3, 12, 5, 59).timestamp()),
+            ("after-end", "excluded", datetime.datetime(2026, 3, 12, 6, 1).timestamp()),
+        ]
+        for line_id, text, timestamp in lines:
+            GameLinesTable(
+                id=line_id,
+                game_name="Test Game",
+                line_text=text,
+                timestamp=timestamp,
+            ).add()
+
+        response = client.get("/api/today-stats")
+
+        assert response.status_code == 200
+        assert response.get_json()["todayTotalChars"] == 3
+
+    def test_today_stats_uses_midnight_window_when_rollover_is_zero(self, client, monkeypatch):
+        self._patch_time(monkeypatch, day_rollover_hour=0)
+        lines = [
+            ("previous-day", "excluded", datetime.datetime(2026, 3, 11, 23, 59).timestamp()),
+            ("midnight", "a", datetime.datetime(2026, 3, 12, 0, 0).timestamp()),
+            ("today", "bc", datetime.datetime(2026, 3, 12, 10, 0).timestamp()),
+        ]
+        for line_id, text, timestamp in lines:
+            GameLinesTable(
+                id=line_id,
+                game_name="Test Game",
+                line_text=text,
+                timestamp=timestamp,
+            ).add()
+
+        response = client.get("/api/today-stats")
+
+        assert response.status_code == 200
+        assert response.get_json()["todayTotalChars"] == 3
 
     def test_today_stats_uses_preloaded_game_metadata_for_linked_lines(self, client, monkeypatch):
         self._patch_time(monkeypatch)

--- a/tests/web/test_stats_settings_api.py
+++ b/tests/web/test_stats_settings_api.py
@@ -28,6 +28,7 @@ def client(app):
 def _stats_config(**overrides):
     values = {
         "session_gap_seconds": 3600,
+        "day_rollover_hour": 4,
         "streak_requirement_hours": 1.0,
         "reading_hours_target": 1500,
         "character_count_target": 25_000_000,
@@ -78,6 +79,18 @@ def test_get_settings_includes_extra_punctuation_regex(client, monkeypatch):
     assert response.status_code == 200
     data = response.get_json()
     assert data["extra_punctuation_regex"] == r"\.?【.*?】"
+
+
+def test_get_settings_includes_day_rollover_hour(client, monkeypatch):
+    monkeypatch.setattr(
+        "GameSentenceMiner.web.database_api.get_stats_config",
+        lambda: _stats_config(day_rollover_hour=6),
+    )
+
+    response = client.get("/api/settings")
+
+    assert response.status_code == 200
+    assert response.get_json()["day_rollover_hour"] == 6
 
 
 def test_post_settings_rejects_legacy_afk_timer_only(client, monkeypatch):
@@ -138,6 +151,51 @@ def test_post_settings_updates_extra_punctuation_regex(client, monkeypatch):
     assert data["extra_punctuation_regex"] == r"\.?【.*?】"
     assert config.extra_punctuation_regex == r"\.?【.*?】"
     assert saved == [config]
+
+
+def test_post_settings_updates_day_rollover_hour(client, monkeypatch):
+    config = _stats_config()
+    saved = []
+    monkeypatch.setattr(
+        "GameSentenceMiner.web.database_api.get_stats_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "GameSentenceMiner.web.database_api.save_stats_config",
+        lambda updated: saved.append(updated),
+    )
+
+    response = client.post("/api/settings", json={"day_rollover_hour": 6})
+
+    assert response.status_code == 200
+    assert response.get_json()["day_rollover_hour"] == 6
+    assert config.day_rollover_hour == 6
+    assert saved == [config]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_error"),
+    [
+        (-1, "Day rollover hour must be between 0 and 23"),
+        (24, "Day rollover hour must be between 0 and 23"),
+        ("not-an-hour", "Day rollover hour must be a valid integer"),
+    ],
+)
+def test_post_settings_rejects_invalid_day_rollover_hour(client, monkeypatch, value, expected_error):
+    config = _stats_config()
+    monkeypatch.setattr(
+        "GameSentenceMiner.web.database_api.get_stats_config",
+        lambda: config,
+    )
+    monkeypatch.setattr(
+        "GameSentenceMiner.web.database_api.save_stats_config",
+        lambda _config: None,
+    )
+
+    response = client.post("/api/settings", json={"day_rollover_hour": value})
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == expected_error
 
 
 def test_post_settings_rejects_invalid_extra_punctuation_regex(client, monkeypatch):


### PR DESCRIPTION
## Summary
- add a configurable 0-23 day rollover hour, defaulting to 4 AM
- apply it only to the Overview Today stats window
- wire the setting through persistence, the settings API, and the statistics modal
- cover defaulting, validation, custom rollover, and midnight behavior

## Testing
- `.venv/bin/python -m pytest -q` (2038 passed, 56 skipped)
- `uv run ruff format GameSentenceMiner tests scripts`
- scoped Ruff checks for changed Python files
- `node --check GameSentenceMiner/web/static/js/shared.js`

AI disclosure: This PR was generated by OpenAI Codex.