### PR TITLE
Fix Electron backend URLs to respect configured GSM bind address

### DIFF
--- a/GameSentenceMiner/web/texthooking_page.py
+++ b/GameSentenceMiner/web/texthooking_page.py
@@ -76,6 +76,19 @@ def _get_legacy_texthooker_port() -> int:
     return 55000 if port < 0 else port
 
 
+def _get_backend_client_host() -> str:
+    try:
+        host = str(get_config().advanced.localhost_bind_address or "localhost").strip()
+    except Exception:
+        host = "localhost"
+
+    if host in {"", "0.0.0.0", "::"}:
+        return "localhost"
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 class _WebsocketInvalidUpgradeLogFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         message = record.getMessage()
@@ -1398,7 +1411,7 @@ def reset_buttons():
 
 
 def open_texthooker():
-    webbrowser.open(f"http://localhost:{_get_single_port()}")
+    webbrowser.open(f"http://{_get_backend_client_host()}:{_get_single_port()}")
 
 
 class _LegacyMovedPageHandler(BaseHTTPRequestHandler):
@@ -1406,10 +1419,10 @@ class _LegacyMovedPageHandler(BaseHTTPRequestHandler):
 
     def _send_moved_page(self, include_body: bool = True):
         current_port = _get_single_port()
-        # Pin host to localhost and strip CR/LF + leading slashes so the Host header / request
-        # path can't be reflected into the Location header (open redirect / header injection).
+        # Use the configured client host and strip CR/LF + leading slashes so the Host header / request
+        # path cannot be reflected into the Location header (open redirect / header injection).
         requested_path = "/" + (self.path or "/").replace("\r", "").replace("\n", "").lstrip("/")
-        new_url = f"http://localhost:{current_port}{requested_path}"
+        new_url = f"http://{_get_backend_client_host()}:{current_port}{requested_path}"
 
         message = textwrap.dedent(f"""
             <!DOCTYPE html>

--- a/electron-src/assets/index.html
+++ b/electron-src/assets/index.html
@@ -634,8 +634,12 @@
             statsLoadInProgress = true;
 
             const settings = await ipcRenderer.invoke('settings.getSettings');
+            const localHostBindAddress = settings?.localhostBindAddress || 'localhost';
+            const singlePort = Number.isFinite(Number(settings?.singlePort)) && Number(settings?.singlePort) > 0
+                ? Math.trunc(Number(settings.singlePort))
+                : 7275;
             const statsEndpoint = settings?.statsEndpoint || 'overview';
-            const statsUrl = `http://localhost:7275/${statsEndpoint}`;
+            const statsUrl = 'http://' + localHostBindAddress + ':' + singlePort + '/' + statsEndpoint;
             const statsIframe = document.querySelector('#stats iframe');
 
             const isAvailable = await waitForStatsEndpoint(statsUrl);

--- a/electron-src/main/gsm_config.ts
+++ b/electron-src/main/gsm_config.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { getBaseDir } from './data_dir.js';
 
 export const DEFAULT_GSM_SINGLE_PORT = 7275;
+export const DEFAULT_GSM_BIND_ADDRESS = "localhost";
 const DEFAULT_GSM_BASE_DIR = getBaseDir();
 
 type JsonObject = Record<string, unknown>;
@@ -79,6 +80,22 @@ export interface GsmProfileList {
     profileScenes: Record<string, string[]>;
 }
 
+export function resolveLocalhostBindAddressFromConfigData(configData: unknown): string {
+	if (!isJsonObject(configData)) {
+		return DEFAULT_GSM_BIND_ADDRESS;
+	}
+	
+	const profileData = getProfileData(configData);
+	if (!profileData || !isJsonObject(profileData.advanced)) {
+		return DEFAULT_GSM_BIND_ADDRESS;
+	}
+	
+	const value = profileData.advanced.localhost_bind_address;
+	return typeof value == "string" && value.trim()
+		? value.trim()
+		: DEFAULT_GSM_BIND_ADDRESS;
+}
+
 export function resolveGsmProfilesFromConfigData(configData: unknown): GsmProfileList {
     if (!isJsonObject(configData) || !isJsonObject(configData.configs)) {
         return { profiles: [], currentProfile: '', profileScenes: {} };
@@ -130,4 +147,19 @@ export function getConfiguredSinglePort(
     } catch {
         return DEFAULT_GSM_SINGLE_PORT;
     }
+}
+
+export function getConfiguredLocalhostBindAddress(
+	configPath = path.join(DEFAULT_GSM_BASE_DIR, 'config.json')
+) : string {
+	try {
+		if (!fs.existsSync(configPath)) {
+			return DEFAULT_GSM_BIND_ADDRESS;
+		}
+		
+		const raw = fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, '');
+		return resolveLocalhostBindAddressFromConfigData(JSON.parse(raw));
+	} catch {
+		return DEFAULT_GSM_BIND_ADDRESS;
+	}
 }

--- a/electron-src/main/main.ts
+++ b/electron-src/main/main.ts
@@ -127,7 +127,7 @@ import {
     registerChangelogProtocolScheme,
 } from './services/changelog_protocol.js';
 import { startInputServer, stopInputServer } from './services/input_server.js';
-import { getConfiguredSinglePort } from './gsm_config.js';
+import { getConfiguredSinglePort, getConfiguredLocalhostBindAddress } from './gsm_config.js';
 import {
     getStatusTrayIconPath,
     getTrayBaseIconPath,
@@ -1005,7 +1005,7 @@ async function pollBackendStatusOnce(): Promise<void> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 1500);
     try {
-        const response = await fetch(`http://localhost:${getConfiguredSinglePort()}/get_status`, {
+        const response = await fetch(`http://${getConfiguredLocalhostBindAddress()}:${getConfiguredSinglePort()}/get_status`, {
             signal: controller.signal,
         });
         if (!response.ok) {

--- a/electron-src/main/ui/obs.ts
+++ b/electron-src/main/ui/obs.ts
@@ -17,6 +17,7 @@ import Store from 'electron-store';
 import * as fs from 'node:fs';
 import * as net from 'node:net';
 import { homedir } from 'node:os';
+import { getConfiguredLocalhostBindAddress } from '../gsm_config.js';
 import { inflateSync } from 'node:zlib';
 import { sendStartOBS } from '../main.js';
 import axios from 'axios';
@@ -2592,7 +2593,7 @@ export async function registerOBSIPC() {
         try {
             const texthookerPort =
                 pythonConfig?.get('configs.Default.general.texthooker_port') || 7275;
-            const response = await axios.get(`http://localhost:${texthookerPort}/get_status`);
+            const response = await axios.get(`http://${getConfiguredLocalhostBindAddress()}:${texthookerPort}/get_status`);
             return response.data;
         } catch (error) {
             // console.error('Error fetching GSM status:', error);

--- a/electron-src/main/ui/settings.ts
+++ b/electron-src/main/ui/settings.ts
@@ -89,7 +89,7 @@ import {
 import type { SceneLaunchProfile } from '../store.js';
 import { APP_NAME, BASE_DIR, getSanitizedPythonEnv } from '../util.js';
 import { syncPythonDisplayLocale } from '../python_locale.js';
-import { getConfiguredSinglePort, getGsmProfileNames } from '../gsm_config.js';
+import { getConfiguredSinglePort, getConfiguredLocalhostBindAddress, getGsmProfileNames } from '../gsm_config.js';
 // Replaced WebSocket usage with stdout IPC helpers
 import {
     closeAllPythonProcesses,
@@ -951,6 +951,7 @@ function getSettingsSnapshot() {
         singlePort: getConfiguredSinglePort(),
         iconStyle: store.get('iconStyle') || 'gsm',
         locale: getLocale(),
+        localhostBindAddress: getConfiguredLocalhostBindAddress(),
         theme: getTheme(),
         consoleMode: getConsoleMode(),
         setupWizardVersion: getSetupWizardVersion(),

--- a/electron-src/main/ui/texthook.ts
+++ b/electron-src/main/ui/texthook.ts
@@ -24,7 +24,7 @@ import {
     sanitizeFilename,
 } from '../util.js';
 import { resolveWineLaunch, findLinuxGamePid, type WineLaunchContext } from './linux_wine.js';
-import { getConfiguredSinglePort } from '../gsm_config.js';
+import { getConfiguredSinglePort, getConfiguredLocalhostBindAddress } from '../gsm_config.js';
 import {
     getGameExePathForScene,
     setGameExePathForScene,
@@ -1633,7 +1633,7 @@ function notifyTextHookUserStop(status: TextHookRuntimeStatus): void {
 
 /** Build a URL to the local Python backend (single-port mode). */
 function gsmBackendUrl(routePath: string): string {
-    return `http://localhost:${getConfiguredSinglePort()}${routePath}`;
+    return `http://${getConfiguredLocalhostBindAddress()}:${getConfiguredSinglePort()}${routePath}`;
 }
 
 export function registerTextHookIPC(): void {

--- a/electron-src/renderer/src/App.tsx
+++ b/electron-src/renderer/src/App.tsx
@@ -132,10 +132,12 @@ function StatsPanel({ active }: { active: boolean }) {
     try {
       const settings = await window.ipcRenderer.invoke<{
         statsEndpoint?: string;
+        localhostBindAddress?: string;
         singlePort?: number;
       }>(
         "settings.getSettings"
       );
+      const localHostBindAddress = settings?.localhostBindAddress ?? "localhost";
       const statsEndpoint = settings?.statsEndpoint ?? "overview";
       const singlePort =
         typeof settings?.singlePort === "number" &&
@@ -143,7 +145,7 @@ function StatsPanel({ active }: { active: boolean }) {
         settings.singlePort > 0
           ? Math.trunc(settings.singlePort)
           : 7275;
-      const statsUrl = `http://localhost:${singlePort}/${statsEndpoint}`;
+      const statsUrl = `http://${localHostBindAddress}:${singlePort}/${statsEndpoint}`;
 
       // If this URL already loaded, don't reset to a permanent loading state.
       if (!forceReload && loadedUrlRef.current === statsUrl) {


### PR DESCRIPTION

## Summary

Fix Electron and Python GSM backend URL construction to respect the configured `advanced.localhost_bind_address` instead of hardcoding `localhost`.

- Read `localhost_bind_address` from GSM config in Electron
- Pass `localhostBindAddress` through `settings.getSettings`
- Use configured host for stats tab, backend status polling, texthook IPC, and GSM status checks
- Update Python browser open / legacy moved-page redirect to use the configured client host

## Testing

- `npm exec -- vitest run --config vitest.config.ts electron-src/main/gsm_config.test.ts`
- `npm run build:main`
- `python -m py_compile GameSentenceMiner/web/texthooking_page.py`
- `npm run build`

## Notes

This fixes cases where GSM is bound to a non-localhost address, such as a Tailscale IP, causing Electron UI requests to `localhost` to fail even though the backend is running. Fixes infinite loading in pages such as Stats, unreachable Texthooker URLs, and silent IPC failures when GSM is bound to a non-localhost address.