### PR TITLE
fix: obsws-python `scene_name` having no fallback due to api missmatch

### DIFF
--- a/GameSentenceMiner/obs/actions.py
+++ b/GameSentenceMiner/obs/actions.py
@@ -426,7 +426,7 @@ def get_current_scene(client: obs.ReqClient):
     if svc and svc.state.current_scene:
         return svc.state.current_scene
     response = client.get_current_program_scene()
-    return response.scene_name if response else ""
+    return response.current_program_scene_name if response else ""
 
 
 @with_obs_client(default="", error_msg="Error getting source from scene")
@@ -479,7 +479,7 @@ def get_active_video_sources(client: obs.ReqClient):
     if not current_game:
         try:
             response = client.get_current_program_scene()
-            current_game = response.scene_name if response else ""
+            current_game = response.current_program_scene_name if response else ""
         except Exception:
             current_game = ""
 

--- a/GameSentenceMiner/obs/actions.py
+++ b/GameSentenceMiner/obs/actions.py
@@ -426,7 +426,10 @@ def get_current_scene(client: obs.ReqClient):
     if svc and svc.state.current_scene:
         return svc.state.current_scene
     response = client.get_current_program_scene()
-    return response.current_program_scene_name if response else ""
+    if not response:
+        return ""
+    scene_name = getattr(response, "scene_name", None) or getattr(response, "current_program_scene_name", "")
+    return scene_name or ""
 
 
 @with_obs_client(default="", error_msg="Error getting source from scene")
@@ -479,7 +482,10 @@ def get_active_video_sources(client: obs.ReqClient):
     if not current_game:
         try:
             response = client.get_current_program_scene()
-            current_game = response.current_program_scene_name if response else ""
+            if not response:
+                current_game = ""
+            else:
+                current_game = getattr(response, "scene_name", None) or getattr(response, "current_program_scene_name", "")
         except Exception:
             current_game = ""
 

--- a/GameSentenceMiner/obs/service.py
+++ b/GameSentenceMiner/obs/service.py
@@ -469,7 +469,10 @@ class OBSService:
 
             def _init(client):
                 response = client.get_current_program_scene()
-                scene_name = response.current_program_scene_name if response else ""
+                if not response:
+                    scene_name = ""
+                else:
+                    scene_name = getattr(response, "scene_name", None) or getattr(response, "current_program_scene_name", "")
                 with self._state_lock:
                     self.state.current_scene = scene_name
                 if scene_name:

--- a/GameSentenceMiner/obs/service.py
+++ b/GameSentenceMiner/obs/service.py
@@ -469,7 +469,7 @@ class OBSService:
 
             def _init(client):
                 response = client.get_current_program_scene()
-                scene_name = response.scene_name if response else ""
+                scene_name = response.current_program_scene_name if response else ""
                 with self._state_lock:
                     self.state.current_scene = scene_name
                 if scene_name:


### PR DESCRIPTION
closes #536 
`obsws-python 1.8.0` had some api changes which made `current_program_scene_name` deprecated.

https://github.com/bpwhelan/GameSentenceMiner/blob/ccc7f9201f3b200b26197d8f8c74285bcc4c5392/GameSentenceMiner/obs/service.py#L471-L472

see: https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#getcurrentprogramscene

this pr tries to up its backwards compatibility for OBS by using both `scene_name` and `current_program_scene_name` as a fallback. 

this made it work for `OBS Studio - 30.0.2.1-3build1`

If not merged, at least a mention in the docs should point from which OBS version onward GSM supports.

as for searching and pinpointing the version: see https://github.com/obsproject/obs-websocket/commit/7adfb5874c396580abbc53bc551bde567cca70dd which was the first time it was marked as deprecatedd 