### PR TITLE
Add Unity/TextMeshPro engine hook for Aokana/Aokana EXTRA1/Aokana EXTRA2

### DIFF
--- a/docs/AOKANA_ENGINE_HOOK.md
+++ b/docs/AOKANA_ENGINE_HOOK.md
@@ -1,0 +1,386 @@
+# Aokana built-in engine hook
+
+Support package: `electron-src/assets/engine_hooks/aokana-steam/`
+Decoder: `unity-tmp-v1` (`electron-src/main/engine_hooks/unity_tmp_decoder.ts`)
+
+This is the first Unity game in the catalog, so it adds an engine decoder as well as
+a package. It has no Agent dependency and no Agent fallback: the payload talks only
+to Frida and to the Mono runtime the game already loads.
+
+One package covers all three shipped Aokana titles. They are the same game code on
+two very different Unity versions, which is exactly the case the decoder was built
+for: nothing about any build is baked into the package, so one manifest and one
+payload drive all of them.
+
+## Supported builds
+
+Recorded from the live processes, without modifying them:
+
+| | Aokana | Aokana EXTRA1 | Aokana EXTRA2 |
+| --- | --- | --- | --- |
+| Process | `Aokana.exe` | `AokanaEXTRA1.exe` | `AokanaEXTRA2.exe` |
+| Steam app id | 1044620 | 1340130 | 2206340 |
+| Architecture | `windows`/`ia32` | `windows`/`ia32` | `windows`/`ia32` |
+| Unity | 2018.2.19f1 | 2018.2.19f1 | 2021.3.15f1 (e8e88683f834) |
+| Executable SHA-256 | `9c6a9381…8721eb91` | `30ac4631…52b83c46` | `1ca61a58…eb71ac77` |
+| Mono runtime | `Mono\EmbedRuntime\mono.dll` | `Mono\EmbedRuntime\mono.dll` | `MonoBleedingEdge\EmbedRuntime\mono-2.0-bdwgc.dll` |
+| Text stack | TextMeshPro + `Assembly-CSharp.dll` | TextMeshPro + `Assembly-CSharp.dll` | TextMeshPro + `Assembly-CSharp.dll` |
+
+Full hashes, as recorded in the manifest:
+
+```text
+Aokana        9c6a938189d4e18dfdbd1891204e35d7b3ed1f8325f24386d354b5838721eb91
+AokanaEXTRA1  30ac46318f2f92885fa5387abaec04b563f229a094acd21eb0caea7052b83c46
+AokanaEXTRA2  1ca61a5859818360326a0f7988bc9f65e3e0e2925cdee91b4ec7ba7ceb71ac77
+```
+
+`UnityPlayer.dll` for the EXTRA2 build is
+`1808a42e83819f04c22673a6b6585bcc16daf21255bda505ebdaeffd27ce5f41`.
+
+The hashes are recorded to prefer this package, not to gate it: a later patch of
+either title will still be tried, and the managed-name checks below decide whether it
+is compatible.
+
+### What differs between the two, and why none of it is configured
+
+EXTRA1 matches the base game in every respect below; the contrast is between the two
+Unity versions, not between the three titles.
+
+| | Aokana / EXTRA1 | Aokana EXTRA2 |
+| --- | --- | --- |
+| Mono runtime module | `mono.dll` | `mono-2.0-bdwgc.dll` |
+| `mono_assembly_get_name` exported | no | yes |
+| `TMP_CharacterInfo` array stride | 316 | 356 |
+| `character` / `lineNumber` offsets | 0 / 44 | 0 / 48 |
+| `origin` / `xAdvance` offsets | 264 / 280 | 268 / 272 |
+| `ascender` / `descender` offsets | 268 / 276 | 276 / 284 |
+| `TMP_Text.m_textInfo` offset | 236 | 256 |
+
+Every one of those is read from the runtime at injection time, so the package carries
+none of them. The struct layout even reorders fields between TextMeshPro versions —
+`xAdvance` moves from after `descender` to before it — which is precisely why
+resolving offsets through Mono beats hard-coding them.
+
+`UIAdv.ShowText(string, string, bool)`, the `advtext` field and
+`TextMeshProUGUI.GenerateTextMesh()` are identical across both, so the manifest's
+managed names need no per-build variation.
+
+## Selection logic
+
+`target.executableNames` lists all three executables and `target.knownExecutableSha256`
+all three hashes, the same pattern the other per-game packages use.
+
+No `target.moduleName` is declared, and the decoder deliberately does not require one.
+On a Unity game the executable is only a launcher — the code the hook needs lives in
+the Mono runtime's managed heap — and Unity renames that runtime by version
+(`mono.dll` through 2019, `mono-2.0-bdwgc.dll` since 2020). A package spanning both
+cannot name one, so the payload identifies the runtime by what it is rather than what
+it is called: the single loaded module that exports `mono_get_root_domain`. More than
+one match, or none, fails closed with the module names listed.
+
+No version markers are declared. A Unity launcher's version resource names Unity, not
+the game, so it would not identify these titles.
+
+## Signatures: managed names instead of byte patterns
+
+A Mono game does not need byte patterns, and using them would be strictly worse. Every
+address is resolved through the runtime's own metadata, which is ASLR-safe by
+construction, survives a rebuild that moves code, and fails loudly when a name is
+absent:
+
+- `mono_image_loaded` finds an already-loaded assembly image by name, falling back to
+  `mono_assembly_foreach` + `mono_image_get_name`. Neither re-opens an assembly by
+  path, which can fail or duplicate it. The older runtime does not export
+  `mono_assembly_get_name`, so the image's own name is used instead of the assembly's.
+- `mono_class_from_name` resolves a class from an assembly image, a namespace, and a
+  name. The manifest supplies all three, so a mismatch names the missing class.
+- `mono_class_get_method_from_name` resolves a method by name **and parameter count**,
+  which is what makes the match unique across overloads.
+- `mono_class_get_field_from_name` + `mono_field_get_offset` give field offsets from
+  the loaded class layout, so no offset is hard-coded in the package.
+- `mono_compile_method` returns the JIT entry point that `Interceptor.attach` hooks.
+
+Missing names fail closed with a usable diagnostic, verified live against this build:
+
+```text
+Error: The class UIAdvNotHere is not in Assembly-CSharp.
+Error: The method GenerateTextMeshNope/0 was not found.
+```
+
+No absolute address and no PID is stored anywhere in the package. The offsets below
+are recorded as evidence only; the payload reads them from the runtime every time.
+
+Field offsets observed on the tested build (`ready` diagnostics):
+
+```json
+{"textComponent":40,"textInfo":256,"characterCount":40,"lineCount":60,
+ "characterInfo":12,"lineInfo":24,"characterStride":356,"lineStride":92}
+```
+
+Array-element offsets inside `TMP_CharacterInfo` / `TMP_LineInfo`, after subtracting
+the Mono object header that `mono_field_get_offset` includes for a value type:
+
+```json
+{"character":0,"lineNumber":48,"origin":268,"xAdvance":272,"ascender":276,"descender":284}
+{"ascender":44,"descender":52}
+```
+
+## The displayed-text lifecycle
+
+`UIAdv.ShowText(string txin, string dispnamein, bool updateonly)` is where one
+displayed line begins. Inside it the engine:
+
+1. splits `txin` per language with `UtilText.SplitLangStr`. The script stores all four
+   localisations in one string separated by U+0002, so the raw argument is **not** the
+   displayed text — capturing it would mine English, Japanese and both Chinese
+   variants at once;
+2. rewrites markup in `prepTextTags` (`--` → `—`, `-` → U+2011, `\n` → newline, and a
+   spacer after `</i>`);
+3. hands the result to `EnsureTextFit`, which assigns it to `advtext` and shrinks the
+   font until it fits;
+4. clears `advtext`, then reveals the line with `TextFader`.
+
+`TextFader` is the reason the geometry is available immediately. It does not add
+characters over time — it emits the **whole** string every frame with per-character
+`<alpha=#xx>` tags, and at the end assigns the untagged string. Every character is
+therefore laid out from the first revealed frame, with its final position.
+
+This also rules out reading the string argument or the component's `m_text`: both
+carry rich-text markup and, during the reveal, colour and alpha tags. The characters
+TextMeshPro actually drew are read instead, so the mined text never contains markup.
+
+### Where the layout is final
+
+`TextMeshProUGUI.GenerateTextMesh()` is the layout pass. Its `onLeave` is the first
+point at which `TMP_TextInfo.characterInfo` and `TMP_TextInfo.lineInfo` are complete
+for the current string, so that is where cells are read.
+
+### Excluding everything that is not the displayed line
+
+- **Other components.** `GenerateTextMesh` runs for every TextMeshPro object in the
+  game — the speaker name, the backlog, the menus, the config screens. Only the
+  instance held in `UIAdv.advtext` is accepted, and that pointer is read from the
+  `UIAdv` instance the dialogue call was made on, so it is the live component rather
+  than a guess.
+- **Measurement passes.** `EnsureTextFit` queries `preferredHeight` up to five times
+  to pick a font size. Those go through TMP's preferred-values path, not
+  `GenerateTextMesh`, so they never reach the hook.
+- **The clearing pass.** `ShowText` sets `advtext.text = ""` before the reveal. That
+  produces a layout with `characterCount == 0`, which is treated as "the line is still
+  to come" and leaves the pending line armed.
+- **Redraws.** Only the first layout after a dialogue call is emitted; the pending line
+  is cleared once used, so the reveal's remaining frames — which repeat the same
+  positions — are ignored.
+- **Re-application.** `UIAdv.ReapplyText` calls `ShowText(..., updateonly: true)` when
+  the player changes language, font or text speed. That is the same line again, so it
+  is reported as capture mode `1` and `capture.acceptedModes` (`[0]`) drops it.
+- **Stale pairing.** A pending line older than five seconds is discarded rather than
+  paired with an unrelated later redraw of the same component.
+
+## Geometry
+
+`TMP_CharacterInfo` gives, per character, the pen positions `origin` and `xAdvance`
+and the glyph's own box, all in the text component's **local** space —
+not in client pixels, and not in any fixed design resolution.
+
+The package resolves them through the engine's own state:
+
+1. `Component.get_transform` → `Transform.get_localToWorldMatrix` puts a local point
+   into world space. Unity stores the matrix column-major, so the translation is at
+   linear indices 12–14.
+2. `Graphic.get_canvas` → `Canvas.get_worldCamera` finds the camera that draws the
+   canvas. On this build the ADV canvas is `Game`, render mode `1`
+   (*Screen Space – Camera*), drawn by `TopCamera` with `targetTexture == null`.
+3. A UI canvas is a plane, so world-to-screen over it is affine regardless of canvas
+   scale or camera placement. Three reference points — local `(0,0)`, `(1,0)`, `(0,1)`
+   — through `Camera.WorldToScreenPoint` pin that map down exactly, at three managed
+   calls per line instead of two per character.
+4. `Camera.get_pixelRect` gives the viewport those screen points live in. Cells are
+   normalised by it and scaled to the client area from `GetClientRect`, called
+   **inside** the game process so the values are the physical pixels the game renders
+   at. The engine's Y grows up from the bottom of the viewport; the overlay's grows
+   down from the top of the client area, so Y is flipped at this point.
+
+`Canvas.get_scaleFactor` is deliberately **not** used as the transform. It is observed
+(1.9 at 3648×2052, 0.833 at 1600×900) and it is already folded into the matrix in
+step 1; applying it again would double-count it.
+
+A `GetClientRect` result on its own would not have proved the space, and neither
+would the canvas scale factor. The derivation above was checked against screenshots
+at two client sizes (below), which is what actually proves it.
+
+If a future Unity target uses a *Screen Space – Overlay* canvas, `worldCamera` is
+null; the payload then treats world X/Y as screen pixels, which is Unity's own
+convention for that mode, and uses `Screen.width`/`Screen.height` as the viewport.
+That path is implemented but is not exercised by this game.
+
+### Cell shape
+
+Each cell spans `origin` → `xAdvance` horizontally and the **line's** ascender →
+descender vertically. Using the line band rather than each glyph's own ink box means
+every cell on a line shares one vertical strip, so the cells tile the line, the
+overlay gets uniform hit boxes, and the decoder can recover lines from a flat list.
+
+### Reported coordinate space
+
+The payload resolves cells to client pixels itself, so `coordinateSpace.provider` is
+`payload-client-pixels` and the measurement it sends is
+`{clientWidth, clientHeight, scaleX: 1, scaleY: 1}`. No width or height is stored in
+the manifest. Every text event carries a freshly measured client area and a freshly
+derived transform, so resizing the window mid-session is handled.
+
+Corrupt geometry fails closed: a non-finite matrix, an empty viewport, a coordinate
+beyond ±32768, or a negative or oversized cell drops the whole layout and emits an
+`error` diagnostic rather than sending a rectangle.
+
+## Decoding
+
+`unity_tmp_decoder.ts` is a pure, tested module. TextMeshPro already names the
+character at every position, so nothing is reconciled against a candidate string and
+no character table ships with the package. The decoder only has to:
+
+- drop what TMP lays out but never draws — control characters, `U+200B`–`U+200D`,
+  `U+FEFF`, `U+2028`, `U+2029` — which carry positions and would otherwise put empty
+  cells over the text;
+- recover lines. The payload gives every cell on a line the same vertical band, so a
+  change of `y` is exactly a line break. Contiguous runs are used rather than grouping
+  by value, so a band the engine returns to starts a new line;
+- trim the padding spaces at both ends of a line while keeping interior ones;
+- join line texts with `\n`.
+
+Reading order is preserved as the engine reported it; cells are never sorted by
+position, so a centred or reordered line is not scrambled.
+
+## Advance
+
+`advance.method` is `foreground-key` with `virtualKey` 13 (`VK_RETURN`) and
+`scanCode` 28. `UIFlow.OnGUI` acts on `EventType.KeyUp` for `KeyCode.Return`,
+`KeyCode.KeypadEnter` and `(KeyCode)10`, calling `EngineMain.UserInputClick`, so a key
+release is what progresses the game.
+
+The payload activates the window (`AttachThreadInput` → `ShowWindow` →
+`BringWindowToTop` → `SetForegroundWindow`), waits 50 ms, holds the key for 60 ms so a
+polling frame cannot miss it, releases it, then detaches the input queues it attached.
+The RPC resolves with `{delivery, activated, foregroundAtDelivery}`.
+
+One RPC call is one progression. Verified live: with `--lines=2`, a single advance
+produced exactly one `text-layout` and the runner then timed out waiting for a second.
+
+```text
+{"type":"advance","window":"0x1d0294","delivery":"foreground-keyboard","activated":1,"foregroundAtDelivery":true}
+  "text": "「そんなことあるよ」"
+Error: No text layout arrived within 9000 ms.
+```
+
+## Live validation
+
+```powershell
+npm run build:main
+node scripts/engine-hooks/run-support.mjs --support=aokana-steam --pid=<pid> --advance --timeout=12000
+```
+
+`ready` on the tested build:
+
+```json
+{"integrationId":"aokana-steam","module":"mono-2.0-bdwgc.dll","moduleSize":6467584,
+ "assemblies":42,"dialogue":"UIAdv.ShowText/3","layout":"TextMeshProUGUI.GenerateTextMesh/0",
+ "offsets":{"textComponent":40,"textInfo":256,"characterCount":40,"lineCount":60,
+ "characterInfo":12,"lineInfo":24,"characterStride":356,"lineStride":92},"maximumGlyphs":600}
+```
+
+EXTRA1, at a 1280×720 client:
+
+```json
+{"mode":0,"style":0,
+ "coordinateMeasurement":{"kind":"scaled-window-client","clientWidth":1280,"clientHeight":720,"scaleX":1,"scaleY":1},
+ "text":"「真白と友達になれてホントに嬉しいっ！　はいっ、お肉どうぞ！」",
+ "lines":[{"bounds":{"x":76,"y":552,"width":833,"height":41},"glyphStart":0,"glyphEnd":31}],
+ "glyphCount":31,
+ "firstGlyph":{"engineIndex":0,"text":"「","x":76,"y":552,"width":27,"height":41},
+ "lastGlyph":{"engineIndex":30,"text":"」","x":882,"y":552,"width":27,"height":41}}
+```
+
+The base game, at a 3627×2040 client, three wrapped lines:
+
+```json
+{"text":"「保守的？　この言葉であってるのかわからないけど、変わることが怖いって
+気持ちがずっとあって……。蚊取り線香の匂いで、それが蘇った、というか
+……」",
+ "lines":[{"x":216,"y":1564,"width":2665,"height":117},
+          {"x":216,"y":1683,"width":2588,"height":117},
+          {"x":216,"y":1802,"width":228,"height":117}],
+ "glyphCount":72}
+```
+
+It was also checked at a 1600×900 client on the same build, where the boxes still
+landed on the glyphs — the 2018 canvas rescales exactly as the 2021 one does.
+
+### EXTRA2, 1600×900 client
+
+```json
+{"mode":0,"style":0,
+ "coordinateMeasurement":{"kind":"scaled-window-client","clientWidth":1600,"clientHeight":900,"scaleX":1,"scaleY":1},
+ "coordinateSpace":{"kind":"engine-logical","width":1600,"height":900},
+ "text":"「いや、あの……。さっきも言ってましたけど、あたしがいい試合したからっ\nていっぱい売れるとか、本当はそんなことないですよね？」",
+ "lines":[{"bounds":{"x":95,"y":690,"width":1176,"height":51},"glyphStart":0,"glyphEnd":35},
+          {"bounds":{"x":95,"y":741,"width":908,"height":51},"glyphStart":35,"glyphEnd":62}],
+ "glyphCount":62,
+ "firstGlyph":{"engineIndex":0,"text":"「","x":95,"y":690,"width":34,"height":51},
+ "lastGlyph":{"engineIndex":61,"text":"」","x":969,"y":741,"width":34,"height":51}}
+```
+
+### EXTRA2, 3648×2052 client
+
+```json
+{"coordinateMeasurement":{"kind":"scaled-window-client","clientWidth":3648,"clientHeight":2052,"scaleX":1,"scaleY":1},
+ "text":"「冗談ではなく。会場が盛り上がれば高揚した観客がいろいろ買ってくれるん\nだ。みさきちゃんだって買い物中にテンションが上がって無駄遣いしてしまっ\nた、そんな経験あるんじゃない？」",
+ "lines":[{"x":217,"y":1573,"width":2681,"height":116},
+          {"x":217,"y":1690,"width":2681,"height":116},
+          {"x":217,"y":1806,"width":1226,"height":116}],
+ "glyphCount":86,
+ "firstGlyph":{"engineIndex":0,"text":"「","x":217,"y":1573,"width":77,"height":116},
+ "lastGlyph":{"engineIndex":85,"text":"」","x":1366,"y":1806,"width":77,"height":116}}
+```
+
+Every capture above was confirmed visually: the decoded text matched the dialogue box
+character for character, and every cell drawn from these rectangles landed on its
+glyph, with the line bands covering exactly the rows the game rendered. Across the
+EXTRA2 pair the canvas scale factor differs (1.9 versus 0.833) and the client-pixel
+results still line up, which is what shows the transform is measured rather than
+assumed. The same held on the 2018 builds at two sizes.
+
+To draw the boxes over a screenshot yourself, the same package can be dumped in full:
+
+```powershell
+node scripts/engine-hooks/dump-support-boxes.mjs --support=aokana-steam --pid=<pid> --out=boxes.json --advance
+```
+
+## Discovery probe
+
+`scripts/engine-hooks/probe-unity-mono.mjs` (with `probe-unity-mono.agent.js`) is the
+probe this package was built from. It resolves the same managed members, dumps class
+layouts and field offsets, and reports the canvas, camera, transform and raw cells for
+each dialogue line. It reads only class metadata and the objects the hooks hand it —
+there is no memory scan of any kind, blocking or otherwise, so it cannot destabilise
+the target. No probe destabilised this game during development.
+
+## Limitations
+
+- Only the dialogue line is captured. The speaker name is a separate TextMeshPro
+  component (`UIAdv.nametext`) and is not mined.
+- Backlog, choices, menus and tooltips are deliberately excluded.
+- `TMP_CharacterInfo.character` is a single UTF-16 code unit. The payload rejoins a
+  surrogate pair when TextMeshPro emits one, but if a build truncates an astral code
+  point into one cell it cannot be recovered. Japanese script is unaffected.
+- Ruby/furigana is not handled, because this title does not use it.
+- The dialogue call is game code, so this package covers the Aokana titles that share
+  it. Another Unity + TextMeshPro game reuses `unity-tmp-v1` and the payload by
+  shipping its own package naming that game's dialogue class, method and text field.
+- The package assumes exactly one Mono runtime is loaded. A process that also hosts a
+  second Mono is refused rather than guessed at.
+
+## Attribution
+
+See `electron-src/assets/engine_hooks/aokana-steam/NOTICE.md`. The package
+ships no copied resources; the foreground-activation and held-key sequence follows
+this repository's own `bgi-ethornell` package.

--- a/electron-src/assets/engine_hooks/aokana-steam/NOTICE.md
+++ b/electron-src/assets/engine_hooks/aokana-steam/NOTICE.md
@@ -1,0 +1,31 @@
+# Aokana EXTRA2 engine-hook resources
+
+This package ships no copied resources. TextMeshPro reports Unicode characters and
+their positions directly, so there is no character set, compound-character map, or
+font table to include, and the package is `manifest.json` plus `payload.js` only.
+
+Everything in it was derived independently for GameSentenceMiner against the live
+Steam build recorded in `manifest.json`:
+
+- the choice of `UIAdv.ShowText` as the point where one displayed line begins, and
+  of its `updateonly` parameter as the re-application flag;
+- the choice of `TextMeshProUGUI.GenerateTextMesh` as the point where the cells for
+  that line are final;
+- reading `TMP_TextInfo.characterInfo` and `TMP_TextInfo.lineInfo` through Mono's
+  own class layout, including the object-header adjustment that turns a value-type
+  field offset into an array-element offset;
+- the three-point derivation of the canvas-to-window transform through the engine's
+  own canvas camera.
+
+`docs/AOKANA_ENGINE_HOOK.md` records how each was established and the live
+evidence for it.
+
+The foreground-activation and held-key sequence in `advance()` follows the same
+approach as this repository's own `bgi-ethornell` package, which is GameSentenceMiner
+code under the repository's licence. No third-party code is included, loaded, or
+invoked, and no Agent script or Agent helper is involved.
+
+The Mono embedding API (`mono_class_from_name`, `mono_field_get_offset`,
+`mono_runtime_invoke`, and the rest) is called through the runtime the game already
+ships, `MonoBleedingEdge/EmbedRuntime/mono-2.0-bdwgc.dll`. Mono is distributed by its
+authors under the MIT licence; nothing from it is redistributed here.

--- a/electron-src/assets/engine_hooks/aokana-steam/manifest.json
+++ b/electron-src/assets/engine_hooks/aokana-steam/manifest.json
@@ -1,0 +1,61 @@
+{
+  "schema": "gsm_engine_hook_manifest_v1",
+  "id": "aokana-steam",
+  "name": "Aokana (Sprite Unity)",
+  "engine": "Unity + TextMeshPro",
+  "decoder": "unity-tmp-v1",
+  "target": {
+    "platform": "windows",
+    "architecture": "ia32",
+    "executableNames": [
+      "Aokana.exe",
+      "AokanaEXTRA1.exe",
+      "AokanaEXTRA2.exe"
+    ],
+    "knownExecutableSha256": [
+      "9c6a938189d4e18dfdbd1891204e35d7b3ed1f8325f24386d354b5838721eb91",
+      "30ac46318f2f92885fa5387abaec04b563f229a094acd21eb0caea7052b83c46",
+      "1ca61a5859818360326a0f7988bc9f65e3e0e2925cdee91b4ec7ba7ceb71ac77"
+    ]
+  },
+  "coordinateSpace": {
+    "provider": "payload-client-pixels"
+  },
+  "payload": "payload.js",
+  "mono": {
+    "dialogue": {
+      "assembly": "Assembly-CSharp",
+      "namespace": "",
+      "class": "UIAdv",
+      "method": "ShowText",
+      "parameterCount": 3,
+      "textComponentField": "advtext",
+      "updateOnlyArgumentIndex": 3
+    },
+    "layout": {
+      "assembly": "Unity.TextMeshPro",
+      "namespace": "TMPro",
+      "class": "TextMeshProUGUI",
+      "method": "GenerateTextMesh",
+      "parameterCount": 0
+    }
+  },
+  "capture": {
+    "acceptedModes": [
+      0
+    ],
+    "maximumGlyphs": 600
+  },
+  "advance": {
+    "method": "foreground-key",
+    "virtualKey": 13,
+    "scanCode": 28
+  },
+  "display": {
+    "details": {
+      "en": "Steam builds of Aokana, EXTRA1 and EXTRA2",
+      "ja": "Aokana／EXTRA1／EXTRA2（Steam版）",
+      "ukr": "Steam-збірки Aokana, EXTRA1 та EXTRA2"
+    }
+  }
+}

--- a/electron-src/assets/engine_hooks/aokana-steam/payload.js
+++ b/electron-src/assets/engine_hooks/aokana-steam/payload.js
@@ -1,0 +1,709 @@
+'use strict';
+
+// Built-in engine hook for the Steam builds of Aokana (Unity 2018.2.19f1) and
+// Aokana EXTRA2 (Unity 2021.3.15f1) — 32-bit Mono, TextMeshPro, same game code.
+//
+// Nothing here is a byte pattern. The game is a managed application, so the Mono
+// runtime is asked for its own metadata: classes by name, methods by name and
+// parameter count, and field offsets from the loaded class layout. That is
+// ASLR-safe by construction and survives a rebuild that moves code around.
+//
+// The dialogue call marks that a line is being shown and names the text component;
+// the TextMeshPro layout call is where that line's cells become final. Cells are
+// mapped to window-client pixels through the engine's own canvas camera, so no
+// resolution is assumed anywhere.
+//
+// See docs/AOKANA_ENGINE_HOOK.md for how each of these was established.
+
+const config = globalThis.__GSM_ENGINE_HOOK_CONFIG__;
+if (!config || config.schema !== 'gsm_engine_hook_manifest_v1') {
+    throw new Error('The engine-hook manifest was not injected.');
+}
+if (Process.platform !== config.target.platform || Process.arch !== config.target.architecture) {
+    throw new Error(
+        `Unsupported target ${Process.platform}/${Process.arch}; expected ` +
+            `${config.target.platform}/${config.target.architecture}.`,
+    );
+}
+
+// A pending line is paired with the next layout that carries characters. Anything
+// later than this belongs to a redraw the player caused, not to that line.
+const PAIRING_WINDOW_MS = 5000;
+const MAX_GLYPHS = Math.min(config.capture.maximumGlyphs, 2000);
+const MAX_LINES = 64;
+const MAX_ABSOLUTE_COORDINATE = 32768;
+const MAX_GLYPH_DIMENSION = 4096;
+// Mono lays a value type out with an object header in front of it, but packs the
+// same type in an array without one.
+const OBJECT_HEADER = Process.pointerSize * 2;
+// MonoArray: MonoObject, then the bounds pointer, then the length, then the payload.
+const ARRAY_LENGTH = Process.pointerSize * 2 + Process.pointerSize;
+const ARRAY_DATA = ARRAY_LENGTH + 4;
+// MonoString: MonoObject, then the length, then UTF-16 code units.
+const STRING_LENGTH = Process.pointerSize * 2;
+const STRING_CHARS = STRING_LENGTH + 4;
+
+// Unity ships the Mono runtime under different names by version — `mono.dll` on
+// 2019 and earlier, `mono-2.0-bdwgc.dll` since 2020 — and a package covering more
+// than one build cannot name both. The runtime is therefore identified by what it
+// is rather than by what it is called: the loaded module that exports the Mono
+// embedding API. A manifest `moduleName` is honoured first when one is given.
+const monoModule = (function findMonoRuntime() {
+    const preferred = config.target.moduleName
+        ? Process.findModuleByName(config.target.moduleName)
+        : null;
+    if (preferred && preferred.findExportByName('mono_get_root_domain')) return preferred;
+    const hosts = Process.enumerateModules().filter((module) =>
+        module.findExportByName('mono_get_root_domain'),
+    );
+    if (hosts.length !== 1) {
+        throw new Error(
+            `Expected exactly one loaded Mono runtime, found ${hosts.length}` +
+                `${hosts.length ? ` (${hosts.map((module) => module.name).join(', ')})` : ''}.`,
+        );
+    }
+    return hosts[0];
+})();
+
+function api(name, retType, argTypes) {
+    const address = monoModule.findExportByName(name);
+    if (!address) throw new Error(`The Mono runtime does not export ${name}.`);
+    return new NativeFunction(address, retType, argTypes);
+}
+
+function optionalApi(name, retType, argTypes) {
+    const address = monoModule.findExportByName(name);
+    return address ? new NativeFunction(address, retType, argTypes) : null;
+}
+
+const mono = {
+    getRootDomain: api('mono_get_root_domain', 'pointer', []),
+    threadAttach: api('mono_thread_attach', 'pointer', ['pointer']),
+    assemblyForeach: api('mono_assembly_foreach', 'void', ['pointer', 'pointer']),
+    assemblyGetImage: api('mono_assembly_get_image', 'pointer', ['pointer']),
+    imageGetName: api('mono_image_get_name', 'pointer', ['pointer']),
+    // Present on every runtime seen so far, but the enumeration below is a complete
+    // substitute, so a runtime without it is still supported.
+    imageLoaded: optionalApi('mono_image_loaded', 'pointer', ['pointer']),
+    classFromName: api('mono_class_from_name', 'pointer', ['pointer', 'pointer', 'pointer']),
+    classGetMethodFromName: api('mono_class_get_method_from_name', 'pointer', ['pointer', 'pointer', 'int']),
+    classGetFieldFromName: api('mono_class_get_field_from_name', 'pointer', ['pointer', 'pointer']),
+    classGetName: api('mono_class_get_name', 'pointer', ['pointer']),
+    classArrayElementSize: api('mono_class_array_element_size', 'int', ['pointer']),
+    fieldGetOffset: api('mono_field_get_offset', 'int', ['pointer']),
+    compileMethod: api('mono_compile_method', 'pointer', ['pointer']),
+    objectGetClass: api('mono_object_get_class', 'pointer', ['pointer']),
+    objectUnbox: api('mono_object_unbox', 'pointer', ['pointer']),
+    runtimeInvoke: api('mono_runtime_invoke', 'pointer', ['pointer', 'pointer', 'pointer', 'pointer']),
+};
+
+const rootDomain = mono.getRootDomain();
+if (rootDomain.isNull()) throw new Error('The Mono root domain is not up yet.');
+mono.threadAttach(rootDomain);
+
+const internedStrings = {};
+function cstr(text) {
+    if (!internedStrings[text]) internedStrings[text] = Memory.allocUtf8String(text);
+    return internedStrings[text];
+}
+
+function readCString(pointer) {
+    return pointer.isNull() ? null : pointer.readUtf8String();
+}
+
+// Images are looked up among what the runtime has already loaded rather than opened
+// by path: the game has loaded everything it uses, and re-opening an assembly can
+// fail or duplicate it.
+let loadedImages = null;
+function collectImages() {
+    if (loadedImages) return loadedImages;
+    loadedImages = {};
+    const visit = new NativeCallback(
+        (assembly) => {
+            const image = mono.assemblyGetImage(assembly);
+            const name = image.isNull() ? null : readCString(mono.imageGetName(image));
+            if (name) loadedImages[name] = image;
+        },
+        'void',
+        ['pointer', 'pointer'],
+    );
+    mono.assemblyForeach(visit, NULL);
+    return loadedImages;
+}
+
+const images = {};
+function image(assemblyName) {
+    if (!images[assemblyName]) {
+        const direct = mono.imageLoaded ? mono.imageLoaded(cstr(assemblyName)) : NULL;
+        const found = direct.isNull() ? collectImages()[assemblyName] : direct;
+        if (!found || found.isNull()) {
+            throw new Error(
+                `The assembly ${assemblyName} is not loaded; the process is not a supported build.`,
+            );
+        }
+        images[assemblyName] = found;
+    }
+    return images[assemblyName];
+}
+
+function klass(assemblyName, namespace, name) {
+    const found = mono.classFromName(image(assemblyName), cstr(namespace), cstr(name));
+    if (found.isNull()) {
+        throw new Error(`The class ${namespace ? `${namespace}.` : ''}${name} is not in ${assemblyName}.`);
+    }
+    return found;
+}
+
+function method(cls, name, parameterCount) {
+    const found = mono.classGetMethodFromName(cls, cstr(name), parameterCount);
+    if (found.isNull()) throw new Error(`The method ${name}/${parameterCount} was not found.`);
+    return found;
+}
+
+function fieldOffset(cls, name) {
+    const field = mono.classGetFieldFromName(cls, cstr(name));
+    if (field.isNull()) throw new Error(`The field ${name} was not found.`);
+    return mono.fieldGetOffset(field);
+}
+
+function readMonoString(pointer) {
+    if (!pointer || pointer.isNull()) return null;
+    const length = pointer.add(STRING_LENGTH).readS32();
+    if (length < 0 || length > 20000) return null;
+    return pointer.add(STRING_CHARS).readUtf16String(length);
+}
+
+const exceptionSlot = Memory.alloc(Process.pointerSize);
+const singleArgumentSlot = Memory.alloc(Process.pointerSize);
+
+function invoke(monoMethod, instance, argv) {
+    exceptionSlot.writePointer(NULL);
+    const result = mono.runtimeInvoke(monoMethod, instance || NULL, argv || NULL, exceptionSlot);
+    const exception = exceptionSlot.readPointer();
+    if (!exception.isNull()) {
+        throw new Error(`The engine threw ${readCString(mono.classGetName(mono.objectGetClass(exception)))}.`);
+    }
+    return result;
+}
+
+function invokeInt(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, NULL);
+    return boxed.isNull() ? null : mono.objectUnbox(boxed).readS32();
+}
+
+function invokeObject(monoMethod, instance) {
+    const result = invoke(monoMethod, instance, NULL);
+    return result.isNull() ? null : result;
+}
+
+function invokeMatrix(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, NULL);
+    if (boxed.isNull()) return null;
+    const raw = mono.objectUnbox(boxed);
+    const values = [];
+    for (let index = 0; index < 16; index += 1) values.push(raw.add(index * 4).readFloat());
+    return values;
+}
+
+function invokeRect(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, NULL);
+    if (boxed.isNull()) return null;
+    const raw = mono.objectUnbox(boxed);
+    return {
+        x: raw.readFloat(),
+        y: raw.add(4).readFloat(),
+        width: raw.add(8).readFloat(),
+        height: raw.add(12).readFloat(),
+    };
+}
+
+// --- managed members ---------------------------------------------------------
+
+const dialogueConfig = config.mono.dialogue;
+const layoutConfig = config.mono.layout;
+
+const dialogueClass = klass(dialogueConfig.assembly, dialogueConfig.namespace, dialogueConfig.class);
+const layoutClass = klass(layoutConfig.assembly, layoutConfig.namespace, layoutConfig.class);
+// TextMeshPro's own types come from the same assembly as the layout call, so the
+// package stays in control of where they are looked up.
+const tmpTextClass = klass(layoutConfig.assembly, layoutConfig.namespace, 'TMP_Text');
+const tmpTextInfoClass = klass(layoutConfig.assembly, layoutConfig.namespace, 'TMP_TextInfo');
+const tmpCharacterInfoClass = klass(layoutConfig.assembly, layoutConfig.namespace, 'TMP_CharacterInfo');
+const tmpLineInfoClass = klass(layoutConfig.assembly, layoutConfig.namespace, 'TMP_LineInfo');
+
+const CORE = 'UnityEngine.CoreModule';
+const canvasClass = klass('UnityEngine.UIModule', 'UnityEngine', 'Canvas');
+const cameraClass = klass(CORE, 'UnityEngine', 'Camera');
+const screenClass = klass(CORE, 'UnityEngine', 'Screen');
+const transformClass = klass(CORE, 'UnityEngine', 'Transform');
+const componentClass = klass(CORE, 'UnityEngine', 'Component');
+const graphicClass = klass('UnityEngine.UI', 'UnityEngine.UI', 'Graphic');
+
+const offsets = {
+    textComponent: fieldOffset(dialogueClass, dialogueConfig.textComponentField),
+    textInfo: fieldOffset(tmpTextClass, 'm_textInfo'),
+    characterCount: fieldOffset(tmpTextInfoClass, 'characterCount'),
+    lineCount: fieldOffset(tmpTextInfoClass, 'lineCount'),
+    characterInfo: fieldOffset(tmpTextInfoClass, 'characterInfo'),
+    lineInfo: fieldOffset(tmpTextInfoClass, 'lineInfo'),
+    characterStride: mono.classArrayElementSize(tmpCharacterInfoClass),
+    lineStride: mono.classArrayElementSize(tmpLineInfoClass),
+};
+
+const characterField = (name) => fieldOffset(tmpCharacterInfoClass, name) - OBJECT_HEADER;
+const lineField = (name) => fieldOffset(tmpLineInfoClass, name) - OBJECT_HEADER;
+const character = {
+    character: characterField('character'),
+    lineNumber: characterField('lineNumber'),
+    origin: characterField('origin'),
+    xAdvance: characterField('xAdvance'),
+    ascender: characterField('ascender'),
+    descender: characterField('descender'),
+};
+const lineMetrics = {
+    ascender: lineField('ascender'),
+    descender: lineField('descender'),
+};
+
+const methods = {
+    dialogue: method(dialogueClass, dialogueConfig.method, dialogueConfig.parameterCount),
+    layout: method(layoutClass, layoutConfig.method, layoutConfig.parameterCount),
+    transform: method(componentClass, 'get_transform', 0),
+    localToWorld: method(transformClass, 'get_localToWorldMatrix', 0),
+    graphicCanvas: method(graphicClass, 'get_canvas', 0),
+    canvasWorldCamera: method(canvasClass, 'get_worldCamera', 0),
+    cameraPixelRect: method(cameraClass, 'get_pixelRect', 0),
+    worldToScreenPoint: method(cameraClass, 'WorldToScreenPoint', 1),
+    screenWidth: method(screenClass, 'get_width', 0),
+    screenHeight: method(screenClass, 'get_height', 0),
+};
+
+// --- window ------------------------------------------------------------------
+
+const user32 = {
+    enumWindows: new NativeFunction(Module.getGlobalExportByName('EnumWindows'), 'bool', ['pointer', 'pointer']),
+    getWindowThreadProcessId: new NativeFunction(
+        Module.getGlobalExportByName('GetWindowThreadProcessId'),
+        'uint32',
+        ['pointer', 'pointer'],
+    ),
+    isWindowVisible: new NativeFunction(Module.getGlobalExportByName('IsWindowVisible'), 'bool', ['pointer']),
+    getClientRect: new NativeFunction(Module.getGlobalExportByName('GetClientRect'), 'bool', ['pointer', 'pointer']),
+};
+
+function findMainWindow() {
+    const processIdBuffer = Memory.alloc(4);
+    let result = NULL;
+    const callback = new NativeCallback(
+        (window) => {
+            processIdBuffer.writeU32(0);
+            user32.getWindowThreadProcessId(window, processIdBuffer);
+            if (processIdBuffer.readU32() === Process.id && user32.isWindowVisible(window)) {
+                result = window;
+                return 0;
+            }
+            return 1;
+        },
+        'bool',
+        ['pointer', 'pointer'],
+    );
+    user32.enumWindows(callback, NULL);
+    return result;
+}
+
+function readClientArea() {
+    const window = findMainWindow();
+    if (window.isNull()) throw new Error('No visible target window was found.');
+    const clientRect = Memory.alloc(16);
+    if (!user32.getClientRect(window, clientRect)) throw new Error('Could not read the target client area.');
+    const width = clientRect.add(8).readS32();
+    const height = clientRect.add(12).readS32();
+    if (width <= 0 || height <= 0) throw new Error(`Invalid target client area ${width}x${height}.`);
+    return { width, height };
+}
+
+// --- geometry ----------------------------------------------------------------
+
+const vectorArgument = Memory.alloc(12);
+
+function worldToScreen(camera, point) {
+    vectorArgument.writeFloat(point[0]);
+    vectorArgument.add(4).writeFloat(point[1]);
+    vectorArgument.add(8).writeFloat(point[2]);
+    singleArgumentSlot.writePointer(vectorArgument);
+    const boxed = invoke(methods.worldToScreenPoint, camera, singleArgumentSlot);
+    if (boxed.isNull()) throw new Error('The canvas camera returned no screen point.');
+    const raw = mono.objectUnbox(boxed);
+    return [raw.readFloat(), raw.add(4).readFloat()];
+}
+
+function localToWorld(matrix, x, y) {
+    return [
+        matrix[0] * x + matrix[4] * y + matrix[12],
+        matrix[1] * x + matrix[5] * y + matrix[13],
+        matrix[2] * x + matrix[6] * y + matrix[14],
+    ];
+}
+
+/**
+ * Pins down how the text component's local space lands in the window.
+ *
+ * A UI canvas is a plane, so the map from it to the screen is affine no matter how
+ * the canvas is scaled or where the camera sits. Three reference points through the
+ * engine's own projection therefore describe it exactly, and cost three managed
+ * calls per line instead of two per character.
+ */
+function measureSurface(textComponent) {
+    const transform = invokeObject(methods.transform, textComponent);
+    if (!transform) throw new Error('The text component has no transform.');
+    const matrix = invokeMatrix(methods.localToWorld, transform);
+    if (!matrix || matrix.some((value) => !Number.isFinite(value))) {
+        throw new Error('The text component reported an unusable transform.');
+    }
+    const canvas = invokeObject(methods.graphicCanvas, textComponent);
+    const camera = canvas ? invokeObject(methods.canvasWorldCamera, canvas) : null;
+    const client = readClientArea();
+
+    let project;
+    let viewport;
+    if (camera) {
+        const pixelRect = invokeRect(methods.cameraPixelRect, camera);
+        if (!pixelRect || !(pixelRect.width > 0) || !(pixelRect.height > 0)) {
+            throw new Error('The canvas camera reported an empty viewport.');
+        }
+        viewport = pixelRect;
+        const origin = worldToScreen(camera, localToWorld(matrix, 0, 0));
+        const unitX = worldToScreen(camera, localToWorld(matrix, 1, 0));
+        const unitY = worldToScreen(camera, localToWorld(matrix, 0, 1));
+        project = {
+            originX: origin[0],
+            originY: origin[1],
+            xAxis: [unitX[0] - origin[0], unitX[1] - origin[1]],
+            yAxis: [unitY[0] - origin[0], unitY[1] - origin[1]],
+        };
+    } else {
+        // A screen-space-overlay canvas is authored directly in screen pixels, so
+        // the world position of a cell is already where it is drawn.
+        const width = invokeInt(methods.screenWidth, null);
+        const height = invokeInt(methods.screenHeight, null);
+        if (!width || !height) throw new Error('The engine reported no screen size.');
+        viewport = { x: 0, y: 0, width, height };
+        const origin = localToWorld(matrix, 0, 0);
+        const unitX = localToWorld(matrix, 1, 0);
+        const unitY = localToWorld(matrix, 0, 1);
+        project = {
+            originX: origin[0],
+            originY: origin[1],
+            xAxis: [unitX[0] - origin[0], unitX[1] - origin[1]],
+            yAxis: [unitY[0] - origin[0], unitY[1] - origin[1]],
+        };
+    }
+
+    // The engine's Y grows upwards from the bottom of the viewport; the overlay's
+    // grows downwards from the top of the client area.
+    const scaleX = client.width / viewport.width;
+    const scaleY = client.height / viewport.height;
+    return {
+        client,
+        viewport,
+        toClient(x, y) {
+            const screenX = project.originX + x * project.xAxis[0] + y * project.yAxis[0];
+            const screenY = project.originY + x * project.xAxis[1] + y * project.yAxis[1];
+            return [
+                (screenX - viewport.x) * scaleX,
+                client.height - (screenY - viewport.y) * scaleY,
+            ];
+        },
+    };
+}
+
+// --- layout reading ----------------------------------------------------------
+
+function readCells(textComponent, surface) {
+    const textInfo = textComponent.add(offsets.textInfo).readPointer();
+    if (textInfo.isNull()) return null;
+    const characterInfo = textInfo.add(offsets.characterInfo).readPointer();
+    const lineInfo = textInfo.add(offsets.lineInfo).readPointer();
+    if (characterInfo.isNull() || lineInfo.isNull()) return null;
+    const characterCount = Math.min(
+        textInfo.add(offsets.characterCount).readS32(),
+        characterInfo.add(ARRAY_LENGTH).readS32(),
+        MAX_GLYPHS,
+    );
+    const lineCount = Math.min(
+        textInfo.add(offsets.lineCount).readS32(),
+        lineInfo.add(ARRAY_LENGTH).readS32(),
+        MAX_LINES,
+    );
+    if (characterCount <= 0 || lineCount <= 0) return null;
+
+    const bands = [];
+    for (let index = 0; index < lineCount; index += 1) {
+        const entry = lineInfo.add(ARRAY_DATA + index * offsets.lineStride);
+        bands.push({
+            ascender: entry.add(lineMetrics.ascender).readFloat(),
+            descender: entry.add(lineMetrics.descender).readFloat(),
+        });
+    }
+
+    const cells = [];
+    for (let index = 0; index < characterCount; index += 1) {
+        const entry = characterInfo.add(ARRAY_DATA + index * offsets.characterStride);
+        const lineNumber = entry.add(character.lineNumber).readS32();
+        // Every cell on a line uses that line's band, so a line is one rectangle
+        // strip and the overlay never has to guess where a row starts.
+        const band = lineNumber >= 0 && lineNumber < bands.length
+            ? bands[lineNumber]
+            : {
+                  ascender: entry.add(character.ascender).readFloat(),
+                  descender: entry.add(character.descender).readFloat(),
+              };
+        const left = entry.add(character.origin).readFloat();
+        const right = entry.add(character.xAdvance).readFloat();
+        if (![left, right, band.ascender, band.descender].every(Number.isFinite)) return null;
+        const topLeft = surface.toClient(left, band.ascender);
+        const bottomRight = surface.toClient(right, band.descender);
+        const x = Math.round(topLeft[0]);
+        const y = Math.round(topLeft[1]);
+        const width = Math.round(bottomRight[0] - topLeft[0]);
+        const height = Math.round(bottomRight[1] - topLeft[1]);
+        if (
+            !Number.isFinite(x) ||
+            !Number.isFinite(y) ||
+            Math.abs(x) > MAX_ABSOLUTE_COORDINATE ||
+            Math.abs(y) > MAX_ABSOLUTE_COORDINATE ||
+            width < 0 ||
+            height < 0 ||
+            width > MAX_GLYPH_DIMENSION ||
+            height > MAX_GLYPH_DIMENSION
+        ) {
+            return null;
+        }
+        cells.push({ engineIndex: cells.length, code: entry.add(character.character).readU16(), x, y, width, height });
+    }
+    if (cells.length === 0) return null;
+
+    // TextMeshPro stores one UTF-16 code unit per cell, so an astral character
+    // arrives as a surrogate pair that has to be put back together.
+    const merged = [];
+    for (let index = 0; index < cells.length; index += 1) {
+        const cell = cells[index];
+        const next = cells[index + 1];
+        if (cell.code >= 0xd800 && cell.code <= 0xdbff && next && next.code >= 0xdc00 && next.code <= 0xdfff) {
+            merged.push({
+                engineIndex: merged.length,
+                code: (cell.code - 0xd800) * 0x400 + (next.code - 0xdc00) + 0x10000,
+                x: cell.x,
+                y: cell.y,
+                width: next.x + next.width - cell.x,
+                height: cell.height,
+            });
+            index += 1;
+            continue;
+        }
+        merged.push({ ...cell, engineIndex: merged.length });
+    }
+    return merged;
+}
+
+// --- capture -----------------------------------------------------------------
+
+let textComponentInstance = null;
+let pending = null;
+let sequence = 0;
+
+function diagnostic(level, message) {
+    send({ schema: 'gsm_engine_hook_message_v1', type: 'diagnostic', level, message });
+}
+
+Interceptor.attach(mono.compileMethod(methods.dialogue), {
+    onEnter(args) {
+        try {
+            const instance = args[0];
+            if (instance.isNull()) return;
+            textComponentInstance = instance.add(offsets.textComponent).readPointer();
+            if (textComponentInstance.isNull()) {
+                textComponentInstance = null;
+                return;
+            }
+            // The engine re-runs this call to re-apply the line already on screen
+            // after a font or language change. That is the same text, so it is a
+            // different capture mode and the package decides whether to take it.
+            const updateOnly = args[dialogueConfig.updateOnlyArgumentIndex].toInt32() & 0xff ? 1 : 0;
+            pending = config.capture.acceptedModes.includes(updateOnly)
+                ? { mode: updateOnly, at: Date.now() }
+                : null;
+        } catch (error) {
+            pending = null;
+            diagnostic('warn', `Could not read the dialogue call: ${error.message}`);
+        }
+    },
+});
+
+Interceptor.attach(mono.compileMethod(methods.layout), {
+    onEnter(args) {
+        this.textComponent = args[0];
+    },
+    onLeave() {
+        const textComponent = this.textComponent;
+        if (
+            !pending ||
+            !textComponentInstance ||
+            textComponent.isNull() ||
+            !textComponent.equals(textComponentInstance)
+        ) {
+            return;
+        }
+        if (Date.now() - pending.at > PAIRING_WINDOW_MS) {
+            pending = null;
+            return;
+        }
+        let cells;
+        let surface;
+        try {
+            surface = measureSurface(textComponent);
+            cells = readCells(textComponent, surface);
+        } catch (error) {
+            pending = null;
+            diagnostic('error', `Could not measure the dialogue layout: ${error.message}`);
+            return;
+        }
+        // The engine clears the component before it reveals the line, so an empty
+        // layout is that clear and the line is still to come.
+        if (!cells) return;
+        const mode = pending.mode;
+        pending = null;
+        sequence += 1;
+        send({
+            schema: 'gsm_engine_hook_message_v1',
+            type: 'text-layout',
+            integrationId: config.id,
+            sequence,
+            capturedAt: Date.now(),
+            // Managed code is compiled into runtime-owned memory rather than into a
+            // module, so there is no meaningful module offset to report.
+            callerOffset: null,
+            mode,
+            style: 0,
+            coordinateSpace: {
+                kind: 'scaled-window-client',
+                clientWidth: surface.client.width,
+                clientHeight: surface.client.height,
+                // Cells were resolved to client pixels above, so the logical space
+                // is the client area itself.
+                scaleX: 1,
+                scaleY: 1,
+            },
+            positionedCodes: cells,
+        });
+    },
+});
+
+// --- advance -----------------------------------------------------------------
+
+function advance() {
+    const window = findMainWindow();
+    if (window.isNull()) throw new Error('No visible target window was found.');
+    const getForegroundWindow = new NativeFunction(
+        Module.getGlobalExportByName('GetForegroundWindow'),
+        'pointer',
+        [],
+    );
+    const getCurrentThreadId = new NativeFunction(
+        Module.getGlobalExportByName('GetCurrentThreadId'),
+        'uint32',
+        [],
+    );
+    const attachThreadInput = new NativeFunction(
+        Module.getGlobalExportByName('AttachThreadInput'),
+        'bool',
+        ['uint32', 'uint32', 'bool'],
+    );
+    const showWindow = new NativeFunction(Module.getGlobalExportByName('ShowWindow'), 'bool', ['pointer', 'int32']);
+    const bringWindowToTop = new NativeFunction(
+        Module.getGlobalExportByName('BringWindowToTop'),
+        'bool',
+        ['pointer'],
+    );
+    const setForegroundWindow = new NativeFunction(
+        Module.getGlobalExportByName('SetForegroundWindow'),
+        'bool',
+        ['pointer'],
+    );
+    const keybdEvent = new NativeFunction(
+        Module.getGlobalExportByName('keybd_event'),
+        'void',
+        ['uint8', 'uint8', 'uint32', 'pointer'],
+    );
+
+    const foregroundWindow = getForegroundWindow();
+    const currentThread = getCurrentThreadId();
+    const foregroundThread = foregroundWindow.isNull()
+        ? 0
+        : user32.getWindowThreadProcessId(foregroundWindow, NULL);
+    const targetThread = user32.getWindowThreadProcessId(window, NULL);
+    if (foregroundThread && foregroundThread !== currentThread) {
+        attachThreadInput(currentThread, foregroundThread, 1);
+    }
+    if (targetThread && targetThread !== currentThread) {
+        attachThreadInput(currentThread, targetThread, 1);
+    }
+    showWindow(window, 9);
+    bringWindowToTop(window);
+    const activated = setForegroundWindow(window);
+
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const foregroundAtDelivery = getForegroundWindow().equals(window);
+            keybdEvent(config.advance.virtualKey, config.advance.scanCode, 0, NULL);
+            // The engine acts on the key release and polls input per frame, so the
+            // key is held across a few frames before it is let go.
+            setTimeout(() => {
+                keybdEvent(config.advance.virtualKey, config.advance.scanCode, 2, NULL);
+                if (targetThread && targetThread !== currentThread) {
+                    attachThreadInput(currentThread, targetThread, 0);
+                }
+                if (foregroundThread && foregroundThread !== currentThread) {
+                    attachThreadInput(currentThread, foregroundThread, 0);
+                }
+                resolve({
+                    window: window.toString(),
+                    sequence,
+                    delivery: 'foreground-keyboard',
+                    activated,
+                    foregroundAtDelivery,
+                });
+            }, 60);
+        }, 50);
+    });
+}
+
+function describe() {
+    return {
+        integrationId: config.id,
+        module: monoModule.name,
+        moduleBase: monoModule.base.toString(),
+        moduleSize: monoModule.size,
+        resolvedImages: Object.keys(images),
+        dialogue: `${dialogueConfig.class}.${dialogueConfig.method}/${dialogueConfig.parameterCount}`,
+        layout: `${layoutConfig.class}.${layoutConfig.method}/${layoutConfig.parameterCount}`,
+        dialogueEntry: mono.compileMethod(methods.dialogue).toString(),
+        layoutEntry: mono.compileMethod(methods.layout).toString(),
+        offsets,
+        characterFieldOffsets: character,
+        lineFieldOffsets: lineMetrics,
+        maximumGlyphs: MAX_GLYPHS,
+    };
+}
+
+rpc.exports = {
+    advance,
+    diagnostics: describe,
+};
+
+send({
+    schema: 'gsm_engine_hook_message_v1',
+    type: 'ready',
+    integrationId: config.id,
+    diagnostics: describe(),
+});

--- a/electron-src/main/engine_hooks/decoders/index.test.ts
+++ b/electron-src/main/engine_hooks/decoders/index.test.ts
@@ -46,7 +46,7 @@ function supportStub(decoder: string): EngineHookSupport {
 
 describe('engine-hook decoder registry', () => {
     it('registers every shipped decoder id', () => {
-        expect(listEngineHookDecoderIds()).toEqual(['bgi-v1', 'mages-v1', 'vlr-v1']);
+        expect(listEngineHookDecoderIds()).toEqual(['bgi-v1', 'mages-v1', 'unity-tmp-v1', 'vlr-v1']);
     });
 
     it('refuses an unknown decoder instead of falling back to one', () => {

--- a/electron-src/main/engine_hooks/decoders/index.ts
+++ b/electron-src/main/engine_hooks/decoders/index.ts
@@ -1,6 +1,7 @@
 import type { EngineHookDecoderDescriptor } from '../manifest.js';
 import { bgiDecoderDescriptor } from './bgi.js';
 import { magesDecoderDescriptor } from './mages.js';
+import { unityTmpDecoderDescriptor } from './unity-tmp.js';
 import { vlrDecoderDescriptor } from './vlr.js';
 
 // One sorted line per engine. A new engine adds its line here and nothing else
@@ -8,6 +9,7 @@ import { vlrDecoderDescriptor } from './vlr.js';
 const ENGINE_HOOK_DECODERS: Record<string, EngineHookDecoderDescriptor> = {
     'bgi-v1': bgiDecoderDescriptor,
     'mages-v1': magesDecoderDescriptor,
+    'unity-tmp-v1': unityTmpDecoderDescriptor,
     'vlr-v1': vlrDecoderDescriptor,
 };
 

--- a/electron-src/main/engine_hooks/decoders/unity-tmp.test.ts
+++ b/electron-src/main/engine_hooks/decoders/unity-tmp.test.ts
@@ -1,0 +1,158 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { loadEngineHookSupport, parseEngineHookManifest } from '../support.js';
+import type { EngineHookUnityTmpManifest } from './unity-tmp.js';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const aokanaDirectory = path.resolve(
+    currentDirectory,
+    '../../../assets/engine_hooks/aokana-steam',
+);
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        schema: 'gsm_engine_hook_manifest_v1',
+        id: 'fixture-unity',
+        name: 'Fixture',
+        engine: 'Unity + TextMeshPro',
+        decoder: 'unity-tmp-v1',
+        target: {
+            platform: 'windows',
+            architecture: 'ia32',
+            executableNames: ['Fixture.exe'],
+        },
+        coordinateSpace: { provider: 'payload-client-pixels' },
+        payload: 'payload.js',
+        mono: {
+            dialogue: {
+                assembly: 'Assembly-CSharp',
+                namespace: '',
+                class: 'UIAdv',
+                method: 'ShowText',
+                parameterCount: 3,
+                textComponentField: 'advtext',
+                updateOnlyArgumentIndex: 3,
+            },
+            layout: {
+                assembly: 'Unity.TextMeshPro',
+                namespace: 'TMPro',
+                class: 'TextMeshProUGUI',
+                method: 'GenerateTextMesh',
+                parameterCount: 0,
+            },
+        },
+        capture: { acceptedModes: [0], maximumGlyphs: 600 },
+        advance: { method: 'foreground-key', virtualKey: 13, scanCode: 28 },
+        display: { details: { en: 'Fixture' } },
+        ...overrides,
+    };
+}
+
+function withMono(change: (mono: Record<string, any>) => void): Record<string, unknown> {
+    const value = manifest();
+    change(value.mono as Record<string, any>);
+    return value;
+}
+
+describe('Unity TextMeshPro manifest', () => {
+    it('accepts a manifest that names every managed member the payload resolves', () => {
+        const parsed = parseEngineHookManifest(manifest()) as EngineHookUnityTmpManifest;
+
+        expect(parsed.decoder).toBe('unity-tmp-v1');
+        expect(parsed.mono.dialogue.class).toBe('UIAdv');
+        expect(parsed.mono.dialogue.namespace).toBe('');
+        expect(parsed.mono.layout.method).toBe('GenerateTextMesh');
+        expect(parsed.capture).toEqual({ acceptedModes: [0], maximumGlyphs: 600 });
+    });
+
+    it('needs no module name, because Unity renames the Mono runtime by version', () => {
+        // `mono.dll` through Unity 2019, `mono-2.0-bdwgc.dll` since 2020. A package
+        // covering both cannot name one, so the payload finds the runtime by the
+        // embedding API it exports.
+        const parsed = parseEngineHookManifest(manifest()) as EngineHookUnityTmpManifest;
+
+        expect(parsed.target.moduleName).toBeUndefined();
+    });
+
+    it('rejects a coordinate space the payload does not produce', () => {
+        expect(() =>
+            parseEngineHookManifest(
+                manifest({
+                    coordinateSpace: {
+                        provider: 'window-client-over-design-space',
+                        designWidth: 1920,
+                        designHeight: 1080,
+                    },
+                }),
+            ),
+        ).toThrow(/must be payload-client-pixels/u);
+    });
+
+    it('rejects an update-only flag that is not one of the declared parameters', () => {
+        expect(() =>
+            parseEngineHookManifest(
+                withMono((mono) => {
+                    mono.dialogue.updateOnlyArgumentIndex = 4;
+                }),
+            ),
+        ).toThrow(/must address a declared parameter/u);
+
+        // Slot zero is the managed `this` pointer, never a flag.
+        expect(() =>
+            parseEngineHookManifest(
+                withMono((mono) => {
+                    mono.dialogue.updateOnlyArgumentIndex = 0;
+                }),
+            ),
+        ).toThrow(/must address a declared parameter/u);
+    });
+
+    it('requires the field that names the text component', () => {
+        expect(() =>
+            parseEngineHookManifest(
+                withMono((mono) => {
+                    delete mono.dialogue.textComponentField;
+                }),
+            ),
+        ).toThrow(/mono.dialogue.textComponentField/u);
+    });
+
+    it('requires the layout member so cells are read only once they are final', () => {
+        expect(() =>
+            parseEngineHookManifest(
+                withMono((mono) => {
+                    delete mono.layout;
+                }),
+            ),
+        ).toThrow(/mono.layout must be an object/u);
+    });
+
+    it('bounds the glyph budget the payload is allowed to send', () => {
+        expect(() =>
+            parseEngineHookManifest(manifest({ capture: { acceptedModes: [0], maximumGlyphs: 5000 } })),
+        ).toThrow(/capture.maximumGlyphs/u);
+    });
+
+    it('loads the checked-in Aokana package, which covers all three shipped builds', () => {
+        const support = loadEngineHookSupport(aokanaDirectory);
+        const parsed = support.manifest as EngineHookUnityTmpManifest;
+
+        expect(parsed.id).toBe('aokana-steam');
+        expect(parsed.decoder).toBe('unity-tmp-v1');
+        expect(parsed.target.executableNames).toEqual([
+            'Aokana.exe',
+            'AokanaEXTRA1.exe',
+            'AokanaEXTRA2.exe',
+        ]);
+        expect(parsed.target.knownExecutableSha256).toEqual([
+            '9c6a938189d4e18dfdbd1891204e35d7b3ed1f8325f24386d354b5838721eb91',
+            '30ac46318f2f92885fa5387abaec04b563f229a094acd21eb0caea7052b83c46',
+            '1ca61a5859818360326a0f7988bc9f65e3e0e2925cdee91b4ec7ba7ceb71ac77',
+        ]);
+        expect(parsed.mono.dialogue.textComponentField).toBe('advtext');
+        expect(support.resources).toBeUndefined();
+        expect(support.payloadSource).toContain('gsm_engine_hook_message_v1');
+    });
+});

--- a/electron-src/main/engine_hooks/decoders/unity-tmp.ts
+++ b/electron-src/main/engine_hooks/decoders/unity-tmp.ts
@@ -1,0 +1,126 @@
+import {
+    nonEmptyString,
+    object,
+    positiveInteger,
+    type EngineHookDecoderDescriptor,
+    type EngineHookManifestBase,
+} from '../manifest.js';
+import { decodeUnityTmpLayout } from '../unity_tmp_decoder.js';
+
+/**
+ * A Unity/Mono game is described by managed names rather than byte patterns: the
+ * Mono runtime resolves classes, methods and field offsets from its own metadata,
+ * which is ASLR-safe by construction and survives a rebuild that moves code.
+ */
+export interface EngineHookUnityTmpMonoMember {
+    assembly: string;
+    /** The global namespace is normal for game code, so an empty string is valid. */
+    namespace: string;
+    class: string;
+    method: string;
+    parameterCount: number;
+}
+
+export interface EngineHookUnityTmpManifest extends EngineHookManifestBase {
+    decoder: 'unity-tmp-v1';
+    mono: {
+        /** The call that starts one displayed line and names the text component. */
+        dialogue: EngineHookUnityTmpMonoMember & {
+            textComponentField: string;
+            /**
+             * Argument slot of the "this is only a re-application" flag, counted from
+             * the managed `this` pointer at slot zero.
+             */
+            updateOnlyArgumentIndex: number;
+        };
+        /** The call that finishes the layout, after which the cells are complete. */
+        layout: EngineHookUnityTmpMonoMember;
+    };
+    capture: {
+        acceptedModes: number[];
+        maximumGlyphs: number;
+    };
+}
+
+const MAXIMUM_GLYPHS = 2000;
+const MAXIMUM_ARGUMENTS = 16;
+
+function namespaceName(value: unknown, label: string): string {
+    if (typeof value !== 'string') throw new Error(`${label} must be a string.`);
+    return value;
+}
+
+function argumentCount(value: unknown, label: string): number {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > MAXIMUM_ARGUMENTS) {
+        throw new Error(`${label} must be an argument count.`);
+    }
+    return value;
+}
+
+function monoMember(value: unknown, label: string): EngineHookUnityTmpMonoMember {
+    const member = object(value, label);
+    return {
+        assembly: nonEmptyString(member.assembly, `${label}.assembly`),
+        namespace: namespaceName(member.namespace, `${label}.namespace`),
+        class: nonEmptyString(member.class, `${label}.class`),
+        method: nonEmptyString(member.method, `${label}.method`),
+        parameterCount: argumentCount(member.parameterCount, `${label}.parameterCount`),
+    };
+}
+
+export const unityTmpDecoderDescriptor: EngineHookDecoderDescriptor = {
+    decoder: 'unity-tmp-v1',
+
+    validateManifest(root, common, context): EngineHookUnityTmpManifest {
+        // The payload converts cells to client pixels itself, because only the engine
+        // knows the canvas render mode and the camera that maps it to the window.
+        if (common.coordinateSpace.provider !== 'payload-client-pixels') {
+            throw new Error('unity-tmp-v1 coordinateSpace.provider must be payload-client-pixels.');
+        }
+        // No module name is required. The module that matters is the Mono runtime,
+        // never the Unity launcher executable, and Unity renames it by version
+        // (`mono.dll` through 2019, `mono-2.0-bdwgc.dll` since 2020). A package
+        // spanning both cannot name one, so the payload identifies the runtime by
+        // the embedding API it exports instead.
+        const acceptedModes = context.requireCaptureModes();
+        const mono = object(root.mono, 'mono');
+        const capture = object(root.capture, 'capture');
+        const dialogue = object(mono.dialogue, 'mono.dialogue');
+        const dialogueMember = monoMember(dialogue, 'mono.dialogue');
+        const updateOnlyArgumentIndex = argumentCount(
+            dialogue.updateOnlyArgumentIndex,
+            'mono.dialogue.updateOnlyArgumentIndex',
+        );
+        // Slot zero is the managed `this` pointer, so a flag can never live there.
+        if (updateOnlyArgumentIndex < 1 || updateOnlyArgumentIndex > dialogueMember.parameterCount) {
+            throw new Error('mono.dialogue.updateOnlyArgumentIndex must address a declared parameter.');
+        }
+        return {
+            ...common,
+            decoder: 'unity-tmp-v1',
+            mono: {
+                dialogue: {
+                    ...dialogueMember,
+                    textComponentField: nonEmptyString(
+                        dialogue.textComponentField,
+                        'mono.dialogue.textComponentField',
+                    ),
+                    updateOnlyArgumentIndex,
+                },
+                layout: monoMember(mono.layout, 'mono.layout'),
+            },
+            capture: {
+                acceptedModes,
+                maximumGlyphs: positiveInteger(
+                    capture.maximumGlyphs,
+                    'capture.maximumGlyphs',
+                    MAXIMUM_GLYPHS,
+                ),
+            },
+        };
+    },
+
+    decodeLayout(message) {
+        return decodeUnityTmpLayout(message.positionedCodes);
+    },
+};

--- a/electron-src/main/engine_hooks/unity_tmp_decoder.test.ts
+++ b/electron-src/main/engine_hooks/unity_tmp_decoder.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeUnityTmpLayout, type UnityTmpPositionedGlyph } from './unity_tmp_decoder.js';
+
+/** One line of same-height cells, the shape the payload reports. */
+function line(text: string, y: number, options: { start?: number; x?: number } = {}) {
+    const startIndex = options.start ?? 0;
+    const startX = options.x ?? 100;
+    return Array.from(text).map((character, index) => ({
+        engineIndex: startIndex + index,
+        code: character.codePointAt(0) ?? 0,
+        x: startX + index * 40,
+        y,
+        width: 40,
+        height: 56,
+    }));
+}
+
+describe('Unity TextMeshPro layout decoder', () => {
+    it('joins one line of cells into the displayed text', () => {
+        const decoded = decodeUnityTmpLayout(line('これは', 600));
+
+        expect(decoded?.text).toBe('これは');
+        expect(decoded?.glyphs).toHaveLength(3);
+        expect(decoded?.glyphs[0]).toEqual({
+            engineIndex: 0,
+            text: 'こ',
+            x: 100,
+            y: 600,
+            width: 40,
+            height: 56,
+        });
+        expect(decoded?.lines).toEqual([
+            { bounds: { x: 100, y: 600, width: 120, height: 56 }, glyphStart: 0, glyphEnd: 3 },
+        ]);
+    });
+
+    it('separates wrapped lines by their shared vertical band, not by a newline character', () => {
+        const decoded = decodeUnityTmpLayout([
+            ...line('あい', 600),
+            ...line('うえ', 660, { start: 2 }),
+        ]);
+
+        expect(decoded?.text).toBe('あい\nうえ');
+        expect(decoded?.lines).toEqual([
+            { bounds: { x: 100, y: 600, width: 80, height: 56 }, glyphStart: 0, glyphEnd: 2 },
+            { bounds: { x: 100, y: 660, width: 80, height: 56 }, glyphStart: 2, glyphEnd: 4 },
+        ]);
+    });
+
+    it('keeps a repeated vertical band separate when the engine returns to it', () => {
+        // Line bands are contiguous runs, so a y value that reappears starts a new
+        // line rather than being merged into the earlier one.
+        const decoded = decodeUnityTmpLayout([
+            ...line('あ', 600),
+            ...line('い', 660, { start: 1 }),
+            ...line('う', 600, { start: 2 }),
+        ]);
+
+        expect(decoded?.lines).toHaveLength(3);
+        expect(decoded?.text).toBe('あ\nい\nう');
+    });
+
+    it('drops leading and trailing spaces from a line but keeps interior ones', () => {
+        const decoded = decodeUnityTmpLayout(line('  a b  ', 600));
+
+        expect(decoded?.text).toBe('a b');
+        expect(decoded?.glyphs).toHaveLength(3);
+        expect(decoded?.glyphs[0].x).toBe(180);
+        expect(decoded?.lines[0].bounds).toEqual({ x: 180, y: 600, width: 120, height: 56 });
+    });
+
+    it('drops control characters the engine lays out but never draws', () => {
+        const decoded = decodeUnityTmpLayout([
+            ...line('あ', 600),
+            { engineIndex: 1, code: 0x0a, x: 140, y: 600, width: 0, height: 56 },
+            { engineIndex: 2, code: 0x200b, x: 140, y: 600, width: 0, height: 56 },
+            ...line('い', 600, { start: 3, x: 140 }),
+        ]);
+
+        expect(decoded?.text).toBe('あい');
+        expect(decoded?.glyphs).toHaveLength(2);
+    });
+
+    it('preserves astral code points as one glyph', () => {
+        const decoded = decodeUnityTmpLayout([
+            { engineIndex: 0, code: 0x1f600, x: 100, y: 600, width: 40, height: 56 },
+        ]);
+
+        expect(decoded?.text).toBe('😀');
+        expect(decoded?.glyphs[0].text).toBe('😀');
+    });
+
+    it('refuses a layout with nothing drawable in it', () => {
+        expect(decodeUnityTmpLayout([])).toBeNull();
+        expect(decodeUnityTmpLayout(line('   ', 600))).toBeNull();
+        expect(
+            decodeUnityTmpLayout([{ engineIndex: 0, code: 0x0a, x: 1, y: 1, width: 0, height: 1 }]),
+        ).toBeNull();
+    });
+
+    it('keeps reading order rather than sorting by position', () => {
+        // The engine already reports characters in reading order; a right-to-left or
+        // centre-aligned line must not be reordered by x.
+        const glyphs: UnityTmpPositionedGlyph[] = [
+            { engineIndex: 0, code: 0x3042, x: 300, y: 10, width: 40, height: 56 },
+            { engineIndex: 1, code: 0x3044, x: 100, y: 10, width: 40, height: 56 },
+        ];
+
+        expect(decodeUnityTmpLayout(glyphs)?.text).toBe('あい');
+        expect(decodeUnityTmpLayout(glyphs)?.lines[0].bounds).toEqual({
+            x: 100,
+            y: 10,
+            width: 240,
+            height: 56,
+        });
+    });
+});

--- a/electron-src/main/engine_hooks/unity_tmp_decoder.ts
+++ b/electron-src/main/engine_hooks/unity_tmp_decoder.ts
@@ -1,0 +1,134 @@
+export interface UnityTmpPositionedGlyph {
+    engineIndex: number;
+    code: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface DecodedUnityTmpGlyph {
+    engineIndex: number;
+    text: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface DecodedUnityTmpLine {
+    bounds: { x: number; y: number; width: number; height: number };
+    glyphStart: number;
+    glyphEnd: number;
+}
+
+export interface DecodedUnityTmpLayout {
+    text: string;
+    glyphs: DecodedUnityTmpGlyph[];
+    lines: DecodedUnityTmpLine[];
+}
+
+/**
+ * Characters TextMeshPro places in its layout but never draws: the line breaks and
+ * zero-width marks it keeps so that indices still line up with the source string.
+ * They carry a position, so leaving them in would put empty cells over the text.
+ */
+function isNonDrawable(code: number): boolean {
+    return (
+        code < 0x20 ||
+        code === 0x7f ||
+        code === 0x200b ||
+        code === 0x200c ||
+        code === 0x200d ||
+        code === 0xfeff ||
+        code === 0x2028 ||
+        code === 0x2029
+    );
+}
+
+function isSpace(code: number): boolean {
+    return code === 0x20 || code === 0x3000 || code === 0xa0;
+}
+
+function boundsFor(
+    glyphs: readonly { x: number; y: number; width: number; height: number }[],
+): DecodedUnityTmpLine['bounds'] {
+    const left = Math.min(...glyphs.map((glyph) => glyph.x));
+    const top = Math.min(...glyphs.map((glyph) => glyph.y));
+    const right = Math.max(...glyphs.map((glyph) => glyph.x + glyph.width));
+    const bottom = Math.max(...glyphs.map((glyph) => glyph.y + glyph.height));
+    return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+/**
+ * Splits the reported cells into lines.
+ *
+ * The payload gives every cell on a line the same vertical band, taken from the
+ * line's own ascender and descender, so a change of `y` is exactly a line break.
+ * Runs are used rather than grouping by value: a centred line and the line under it
+ * can share a band only by the engine returning to it, which is still a new line.
+ */
+function splitLines(
+    glyphs: readonly UnityTmpPositionedGlyph[],
+): UnityTmpPositionedGlyph[][] {
+    const lines: UnityTmpPositionedGlyph[][] = [];
+    let current: UnityTmpPositionedGlyph[] = [];
+    for (const glyph of glyphs) {
+        const previous = current[current.length - 1];
+        if (previous && (previous.y !== glyph.y || previous.height !== glyph.height)) {
+            lines.push(current);
+            current = [];
+        }
+        current.push(glyph);
+    }
+    if (current.length > 0) lines.push(current);
+    return lines;
+}
+
+/** Drops the padding cells at both ends of a line without touching interior spaces. */
+function trimSpaces(glyphs: readonly UnityTmpPositionedGlyph[]): UnityTmpPositionedGlyph[] {
+    let start = 0;
+    let end = glyphs.length;
+    while (start < end && isSpace(glyphs[start].code)) start += 1;
+    while (end > start && isSpace(glyphs[end - 1].code)) end -= 1;
+    return glyphs.slice(start, end);
+}
+
+/**
+ * Turns the cells TextMeshPro laid out into displayed text and exact glyph boxes.
+ *
+ * Unlike the engines that hand over a code stream, TMP already names the character
+ * at every position, so nothing has to be reconciled or looked up in a table. The
+ * decoder's whole job is to drop what the engine lays out but does not draw and to
+ * recover the line structure that the flat cell list lost.
+ */
+export function decodeUnityTmpLayout(
+    positionedGlyphs: readonly UnityTmpPositionedGlyph[],
+): DecodedUnityTmpLayout | null {
+    const drawable = positionedGlyphs.filter((glyph) => !isNonDrawable(glyph.code));
+    if (drawable.length === 0) return null;
+
+    const glyphs: DecodedUnityTmpGlyph[] = [];
+    const lines: DecodedUnityTmpLine[] = [];
+    const lineTexts: string[] = [];
+    for (const rawLine of splitLines(drawable)) {
+        const line = trimSpaces(rawLine);
+        if (line.length === 0) continue;
+        const glyphStart = glyphs.length;
+        for (const glyph of line) {
+            glyphs.push({
+                engineIndex: glyph.engineIndex,
+                text: String.fromCodePoint(glyph.code),
+                x: glyph.x,
+                y: glyph.y,
+                width: glyph.width,
+                height: glyph.height,
+            });
+        }
+        lines.push({ bounds: boundsFor(line), glyphStart, glyphEnd: glyphs.length });
+        lineTexts.push(glyphs.slice(glyphStart).map((glyph) => glyph.text).join(''));
+    }
+    if (glyphs.length === 0) return null;
+
+    return { text: lineTexts.join('\n'), glyphs, lines };
+}

--- a/scripts/engine-hooks/dump-support-boxes.mjs
+++ b/scripts/engine-hooks/dump-support-boxes.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+// Injects a shipped support package, decodes one line through the same decoder
+// registry the app uses, and writes every glyph and line rectangle to a JSON file.
+//
+// run-support.mjs prints only the first and last glyph, which is enough to see that
+// a package works but not enough to draw its boxes over a screenshot. This writes
+// the whole set so the packaged artifact — not a probe — can be confirmed visually.
+//
+// Usage:
+//   node scripts/engine-hooks/dump-support-boxes.mjs --support=<id> --pid=<pid> --out=<file> [--advance]
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import frida, { ScriptRuntime } from 'frida';
+
+import { getEngineHookDecoder } from '../../dist/main/engine_hooks/decoders/index.js';
+import { parseEngineHookManifest } from '../../dist/main/engine_hooks/support.js';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '..', '..');
+const catalogDirectory = path.join(repositoryRoot, 'electron-src', 'assets', 'engine_hooks');
+
+function option(name) {
+    const prefix = `--${name}=`;
+    return process.argv.slice(2).find((argument) => argument.startsWith(prefix))?.slice(prefix.length) ?? null;
+}
+
+const supportId = option('support');
+const pid = Number.parseInt(option('pid') ?? '', 10);
+const outputPath = option('out');
+if (!supportId || !/^[a-z0-9][a-z0-9-]*$/u.test(supportId)) throw new Error('Pass --support=<package-id>.');
+if (!Number.isInteger(pid) || pid <= 0) throw new Error('Pass --pid=<number>.');
+if (!outputPath) throw new Error('Pass --out=<file>.');
+
+const supportDirectory = path.join(catalogDirectory, supportId);
+const manifest = parseEngineHookManifest(
+    JSON.parse(fs.readFileSync(path.join(supportDirectory, 'manifest.json'), 'utf8')),
+);
+const payload = fs.readFileSync(path.join(supportDirectory, manifest.payload), 'utf8');
+const decoder = getEngineHookDecoder(manifest.decoder);
+const support = {
+    directory: supportDirectory,
+    manifest,
+    payloadSource: payload,
+    resources: decoder.loadResources?.(supportDirectory, manifest),
+};
+
+const timeoutMs = Number.parseInt(option('timeout') ?? '15000', 10);
+const session = await frida.attach(pid);
+const script = await session.createScript(
+    `globalThis.__GSM_ENGINE_HOOK_CONFIG__ = ${JSON.stringify(manifest)};\n${payload}`,
+    { name: `${manifest.id}-boxes`, runtime: ScriptRuntime.QJS },
+);
+
+let finish;
+const completed = new Promise((resolve, reject) => {
+    finish = { resolve, reject };
+});
+const timer = setTimeout(() => finish.reject(new Error(`No text layout arrived within ${timeoutMs} ms.`)), timeoutMs);
+
+script.message.connect((message) => {
+    if (message.type === 'error') {
+        finish.reject(new Error(message.stack || message.description));
+        return;
+    }
+    const body = message.payload;
+    if (body?.type === 'ready' && process.argv.includes('--advance')) {
+        void script.exports.advance().catch((error) => finish.reject(error));
+        return;
+    }
+    if (body?.type === 'diagnostic') {
+        process.stderr.write(`${body.level}: ${body.message}\n`);
+        return;
+    }
+    if (body?.type !== 'text-layout') return;
+    const decoded = decoder.decodeLayout(body, support);
+    if (!decoded) return;
+    fs.writeFileSync(
+        outputPath,
+        JSON.stringify({
+            supportId: manifest.id,
+            text: decoded.text,
+            coordinateMeasurement: body.coordinateSpace,
+            glyphs: decoded.glyphs,
+            lines: decoded.lines.map((line) => line.bounds),
+        }),
+    );
+    process.stdout.write(`${JSON.stringify({ text: decoded.text, glyphs: decoded.glyphs.length })}\n`);
+    finish.resolve();
+});
+
+try {
+    await script.load();
+    await completed;
+} finally {
+    clearTimeout(timer);
+    try {
+        if (!script.isDestroyed) await script.unload();
+    } catch {}
+    try {
+        if (!session.isDetached()) await session.detach();
+    } catch {}
+}

--- a/scripts/engine-hooks/probe-unity-mono.agent.js
+++ b/scripts/engine-hooks/probe-unity-mono.agent.js
@@ -1,0 +1,502 @@
+'use strict';
+
+// Injected half of probe-unity-mono.mjs. Everything is resolved through the Mono
+// runtime's own metadata, so nothing here depends on a byte pattern or an RVA.
+
+const DUMP = globalThis.__PROBE_DUMP__ || 'canvas';
+
+const monoModule = Process.getModuleByName('mono-2.0-bdwgc.dll');
+
+function exportByName(name) {
+    const address = monoModule.findExportByName(name);
+    if (!address) throw new Error('Missing Mono export ' + name);
+    return address;
+}
+
+function api(name, retType, argTypes) {
+    return new NativeFunction(exportByName(name), retType, argTypes);
+}
+
+const mono = {
+    get_root_domain: api('mono_get_root_domain', 'pointer', []),
+    thread_attach: api('mono_thread_attach', 'pointer', ['pointer']),
+    assembly_foreach: api('mono_assembly_foreach', 'void', ['pointer', 'pointer']),
+    assembly_get_name: api('mono_assembly_get_name', 'pointer', ['pointer']),
+    assembly_name_get_name: api('mono_assembly_name_get_name', 'pointer', ['pointer']),
+    assembly_get_image: api('mono_assembly_get_image', 'pointer', ['pointer']),
+    class_from_name: api('mono_class_from_name', 'pointer', ['pointer', 'pointer', 'pointer']),
+    class_get_method_from_name: api('mono_class_get_method_from_name', 'pointer', ['pointer', 'pointer', 'int']),
+    class_get_field_from_name: api('mono_class_get_field_from_name', 'pointer', ['pointer', 'pointer']),
+    class_get_fields: api('mono_class_get_fields', 'pointer', ['pointer', 'pointer']),
+    class_get_name: api('mono_class_get_name', 'pointer', ['pointer']),
+    class_array_element_size: api('mono_class_array_element_size', 'int', ['pointer']),
+    field_get_name: api('mono_field_get_name', 'pointer', ['pointer']),
+    field_get_offset: api('mono_field_get_offset', 'int', ['pointer']),
+    compile_method: api('mono_compile_method', 'pointer', ['pointer']),
+    object_get_class: api('mono_object_get_class', 'pointer', ['pointer']),
+    object_unbox: api('mono_object_unbox', 'pointer', ['pointer']),
+    runtime_invoke: api('mono_runtime_invoke', 'pointer', ['pointer', 'pointer', 'pointer', 'pointer']),
+};
+
+const rootDomain = mono.get_root_domain();
+mono.thread_attach(rootDomain);
+
+const cstrCache = {};
+function cstr(text) {
+    if (!cstrCache[text]) cstrCache[text] = Memory.allocUtf8String(text);
+    return cstrCache[text];
+}
+
+function readCString(pointer) {
+    return pointer.isNull() ? null : pointer.readUtf8String();
+}
+
+// The loaded set is enumerated rather than opened by path: Unity has already loaded
+// every assembly the game uses.
+const assemblies = {};
+(function collectAssemblies() {
+    const visit = new NativeCallback(
+        (assembly) => {
+            const name = readCString(mono.assembly_name_get_name(mono.assembly_get_name(assembly)));
+            if (name) assemblies[name] = assembly;
+        },
+        'void',
+        ['pointer', 'pointer'],
+    );
+    mono.assembly_foreach(visit, NULL);
+})();
+
+const imageCache = {};
+function image(assemblyName) {
+    if (!imageCache[assemblyName]) {
+        const assembly = assemblies[assemblyName];
+        if (!assembly) throw new Error('Assembly not loaded: ' + assemblyName);
+        imageCache[assemblyName] = mono.assembly_get_image(assembly);
+    }
+    return imageCache[assemblyName];
+}
+
+function klass(assemblyName, namespace, name) {
+    const found = mono.class_from_name(image(assemblyName), cstr(namespace), cstr(name));
+    if (found.isNull()) throw new Error('Class not found: ' + namespace + '.' + name);
+    return found;
+}
+
+function method(cls, name, argCount) {
+    const found = mono.class_get_method_from_name(cls, cstr(name), argCount);
+    if (found.isNull()) throw new Error('Method not found: ' + name + '/' + argCount);
+    return found;
+}
+
+function optionalMethod(cls, name, argCount) {
+    const found = mono.class_get_method_from_name(cls, cstr(name), argCount);
+    return found.isNull() ? null : found;
+}
+
+function fieldOffset(cls, name) {
+    const field = mono.class_get_field_from_name(cls, cstr(name));
+    if (field.isNull()) throw new Error('Field not found: ' + name);
+    return mono.field_get_offset(field);
+}
+
+// MonoString on 32-bit: MonoObject (8) + int32 length + UTF-16 payload.
+function readMonoString(pointer) {
+    if (!pointer || pointer.isNull()) return null;
+    const length = pointer.add(8).readS32();
+    if (length < 0 || length > 20000) return '<bad length ' + length + '>';
+    return pointer.add(12).readUtf16String(length);
+}
+
+function classNameOf(object) {
+    return !object || object.isNull() ? null : readCString(mono.class_get_name(mono.object_get_class(object)));
+}
+
+const exceptionSlot = Memory.alloc(Process.pointerSize);
+function invoke(monoMethod, instance, args) {
+    exceptionSlot.writePointer(NULL);
+    let argv = NULL;
+    if (args && args.length > 0) {
+        argv = Memory.alloc(Process.pointerSize * args.length);
+        for (let i = 0; i < args.length; i += 1) argv.add(Process.pointerSize * i).writePointer(args[i]);
+    }
+    const result = mono.runtime_invoke(monoMethod, instance || NULL, argv, exceptionSlot);
+    const exception = exceptionSlot.readPointer();
+    if (!exception.isNull()) throw new Error('Managed exception from ' + classNameOf(exception));
+    return result;
+}
+
+function invokeInt(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, []);
+    return boxed.isNull() ? null : mono.object_unbox(boxed).readS32();
+}
+
+function invokeFloat(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, []);
+    return boxed.isNull() ? null : mono.object_unbox(boxed).readFloat();
+}
+
+function invokeObject(monoMethod, instance) {
+    const result = invoke(monoMethod, instance, []);
+    return result.isNull() ? null : result;
+}
+
+function invokeRect(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, []);
+    if (boxed.isNull()) return null;
+    const raw = mono.object_unbox(boxed);
+    return [raw.readFloat(), raw.add(4).readFloat(), raw.add(8).readFloat(), raw.add(12).readFloat()];
+}
+
+function invokeMatrix(monoMethod, instance) {
+    const boxed = invoke(monoMethod, instance, []);
+    if (boxed.isNull()) return null;
+    const raw = mono.object_unbox(boxed);
+    const values = [];
+    for (let i = 0; i < 16; i += 1) values.push(raw.add(i * 4).readFloat());
+    return values;
+}
+
+// --- resolved metadata -------------------------------------------------------
+
+const UIAdv = klass('Assembly-CSharp', '', 'UIAdv');
+const TMP_Text = klass('Unity.TextMeshPro', 'TMPro', 'TMP_Text');
+const TextMeshProUGUI = klass('Unity.TextMeshPro', 'TMPro', 'TextMeshProUGUI');
+const TMP_TextInfo = klass('Unity.TextMeshPro', 'TMPro', 'TMP_TextInfo');
+const TMP_CharacterInfo = klass('Unity.TextMeshPro', 'TMPro', 'TMP_CharacterInfo');
+const TMP_LineInfo = klass('Unity.TextMeshPro', 'TMPro', 'TMP_LineInfo');
+const Canvas = klass('UnityEngine.UIModule', 'UnityEngine', 'Canvas');
+const Camera = klass('UnityEngine.CoreModule', 'UnityEngine', 'Camera');
+const Screen = klass('UnityEngine.CoreModule', 'UnityEngine', 'Screen');
+const Transform = klass('UnityEngine.CoreModule', 'UnityEngine', 'Transform');
+const Component = klass('UnityEngine.CoreModule', 'UnityEngine', 'Component');
+const RenderTexture = klass('UnityEngine.CoreModule', 'UnityEngine', 'RenderTexture');
+const UnityObject = klass('UnityEngine.CoreModule', 'UnityEngine', 'Object');
+
+const offsets = {
+    advtext: fieldOffset(UIAdv, 'advtext'),
+    textInfo: fieldOffset(TMP_Text, 'm_textInfo'),
+    rectTransform: fieldOffset(TMP_Text, 'm_rectTransform'),
+    text: fieldOffset(TMP_Text, 'm_text'),
+    canvas: fieldOffset(TextMeshProUGUI, 'm_canvas'),
+    characterCount: fieldOffset(TMP_TextInfo, 'characterCount'),
+    lineCount: fieldOffset(TMP_TextInfo, 'lineCount'),
+    characterInfo: fieldOffset(TMP_TextInfo, 'characterInfo'),
+    lineInfo: fieldOffset(TMP_TextInfo, 'lineInfo'),
+    characterInfoStride: mono.class_array_element_size(TMP_CharacterInfo),
+    lineInfoStride: mono.class_array_element_size(TMP_LineInfo),
+};
+
+// Value-type field offsets include the MonoObject header; array elements are packed.
+const HEADER = Process.pointerSize * 2;
+const charField = (name) => fieldOffset(TMP_CharacterInfo, name) - HEADER;
+const lineField = (name) => fieldOffset(TMP_LineInfo, name) - HEADER;
+const charInfo = {
+    character: charField('character'),
+    index: charField('index'),
+    lineNumber: charField('lineNumber'),
+    topLeft: charField('topLeft'),
+    bottomLeft: charField('bottomLeft'),
+    topRight: charField('topRight'),
+    bottomRight: charField('bottomRight'),
+    origin: charField('origin'),
+    xAdvance: charField('xAdvance'),
+    ascender: charField('ascender'),
+    descender: charField('descender'),
+    scale: charField('scale'),
+    isVisible: charField('isVisible'),
+};
+const lineInfoOffsets = {
+    firstCharacterIndex: lineField('firstCharacterIndex'),
+    lastCharacterIndex: lineField('lastCharacterIndex'),
+    characterCount: lineField('characterCount'),
+    lineHeight: lineField('lineHeight'),
+    ascender: lineField('ascender'),
+    baseline: lineField('baseline'),
+    descender: lineField('descender'),
+};
+
+const methods = {
+    canvasRenderMode: method(Canvas, 'get_renderMode', 0),
+    canvasWorldCamera: method(Canvas, 'get_worldCamera', 0),
+    canvasScaleFactor: method(Canvas, 'get_scaleFactor', 0),
+    canvasRootCanvas: method(Canvas, 'get_rootCanvas', 0),
+    screenWidth: method(Screen, 'get_width', 0),
+    screenHeight: method(Screen, 'get_height', 0),
+    localToWorld: method(Transform, 'get_localToWorldMatrix', 0),
+    componentTransform: method(Component, 'get_transform', 0),
+    objectName: method(UnityObject, 'get_name', 0),
+    cameraTargetTexture: method(Camera, 'get_targetTexture', 0),
+    cameraWorldToCamera: optionalMethod(Camera, 'get_worldToCameraMatrix', 0),
+    cameraProjection: optionalMethod(Camera, 'get_projectionMatrix', 0),
+    cameraRect: optionalMethod(Camera, 'get_rect', 0),
+    cameraPixelRect: optionalMethod(Camera, 'get_pixelRect', 0),
+    cameraWorldToScreenPoint: optionalMethod(Camera, 'WorldToScreenPoint', 1),
+    cameraPixelWidth: optionalMethod(Camera, 'get_pixelWidth', 0),
+    cameraPixelHeight: optionalMethod(Camera, 'get_pixelHeight', 0),
+    renderTextureWidth: method(RenderTexture, 'get_width', 0),
+    renderTextureHeight: method(RenderTexture, 'get_height', 0),
+};
+
+// The UI canvas is a plane, so world-to-screen is affine over it. Three reference
+// points through the engine's own Camera.WorldToScreenPoint pin that map down
+// exactly, which is far cheaper than one managed call per glyph corner.
+const vectorArg = Memory.alloc(12);
+const argvSlot = Memory.alloc(Process.pointerSize);
+function worldToScreen(camera, x, y, z) {
+    vectorArg.writeFloat(x);
+    vectorArg.add(4).writeFloat(y);
+    vectorArg.add(8).writeFloat(z);
+    argvSlot.writePointer(vectorArg);
+    exceptionSlot.writePointer(NULL);
+    const boxed = mono.runtime_invoke(methods.cameraWorldToScreenPoint, camera, argvSlot, exceptionSlot);
+    if (!exceptionSlot.readPointer().isNull()) throw new Error('WorldToScreenPoint threw.');
+    const raw = mono.object_unbox(boxed);
+    return [raw.readFloat(), raw.add(4).readFloat()];
+}
+
+function localToWorldPoint(matrix, x, y) {
+    return [
+        matrix[0] * x + matrix[4] * y + matrix[12],
+        matrix[1] * x + matrix[5] * y + matrix[13],
+        matrix[2] * x + matrix[6] * y + matrix[14],
+    ];
+}
+
+function deriveScreenTransform(camera, matrix) {
+    const origin = localToWorldPoint(matrix, 0, 0);
+    const unitX = localToWorldPoint(matrix, 1, 0);
+    const unitY = localToWorldPoint(matrix, 0, 1);
+    const s0 = worldToScreen(camera, origin[0], origin[1], origin[2]);
+    const sx = worldToScreen(camera, unitX[0], unitX[1], unitX[2]);
+    const sy = worldToScreen(camera, unitY[0], unitY[1], unitY[2]);
+    return {
+        originX: s0[0],
+        originY: s0[1],
+        xAxis: [sx[0] - s0[0], sx[1] - s0[1]],
+        yAxis: [sy[0] - s0[0], sy[1] - s0[1]],
+    };
+}
+
+function applyScreenTransform(transform, x, y) {
+    return [
+        transform.originX + x * transform.xAxis[0] + y * transform.yAxis[0],
+        transform.originY + x * transform.xAxis[1] + y * transform.yAxis[1],
+    ];
+}
+
+// MonoArray on 32-bit: MonoObject (8) + bounds (4) + max_length (4).
+const ARRAY_DATA = 16;
+const ARRAY_LENGTH = 12;
+
+function readVector3(base, offset) {
+    return [base.add(offset).readFloat(), base.add(offset + 4).readFloat(), base.add(offset + 8).readFloat()];
+}
+
+let advtextInstance = null;
+let pendingLine = null;
+
+function describeCanvas(canvas) {
+    if (!canvas || canvas.isNull()) return null;
+    const rootCanvas = invokeObject(methods.canvasRootCanvas, canvas);
+    const worldCamera = invokeObject(methods.canvasWorldCamera, canvas);
+    let cameraInfo = null;
+    if (worldCamera) {
+        const targetTexture = invokeObject(methods.cameraTargetTexture, worldCamera);
+        cameraInfo = {
+            name: readMonoString(invokeObject(methods.objectName, worldCamera)),
+            pixelWidth: methods.cameraPixelWidth ? invokeInt(methods.cameraPixelWidth, worldCamera) : null,
+            pixelHeight: methods.cameraPixelHeight ? invokeInt(methods.cameraPixelHeight, worldCamera) : null,
+            worldToCamera: methods.cameraWorldToCamera ? invokeMatrix(methods.cameraWorldToCamera, worldCamera) : null,
+            projection: methods.cameraProjection ? invokeMatrix(methods.cameraProjection, worldCamera) : null,
+            rect: methods.cameraRect ? invokeRect(methods.cameraRect, worldCamera) : null,
+            pixelRect: methods.cameraPixelRect ? invokeRect(methods.cameraPixelRect, worldCamera) : null,
+            hasWorldToScreenPoint: methods.cameraWorldToScreenPoint !== null,
+            targetTexture: targetTexture
+                ? {
+                      width: invokeInt(methods.renderTextureWidth, targetTexture),
+                      height: invokeInt(methods.renderTextureHeight, targetTexture),
+                  }
+                : null,
+        };
+    }
+    return {
+        name: readMonoString(invokeObject(methods.objectName, canvas)),
+        renderMode: invokeInt(methods.canvasRenderMode, canvas),
+        scaleFactor: invokeFloat(methods.canvasScaleFactor, canvas),
+        rootName: rootCanvas ? readMonoString(invokeObject(methods.objectName, rootCanvas)) : null,
+        rootRenderMode: rootCanvas ? invokeInt(methods.canvasRenderMode, rootCanvas) : null,
+        rootScaleFactor: rootCanvas ? invokeFloat(methods.canvasScaleFactor, rootCanvas) : null,
+        camera: cameraInfo,
+    };
+}
+
+function readLayout(tmp, sampleSize) {
+    const textInfo = tmp.add(offsets.textInfo).readPointer();
+    if (textInfo.isNull()) return null;
+    const characterCount = textInfo.add(offsets.characterCount).readS32();
+    const lineCount = textInfo.add(offsets.lineCount).readS32();
+    const characterInfo = textInfo.add(offsets.characterInfo).readPointer();
+    const lineInfo = textInfo.add(offsets.lineInfo).readPointer();
+    if (characterInfo.isNull() || characterCount <= 0) return null;
+    const capacity = characterInfo.add(ARRAY_LENGTH).readS32();
+    const count = Math.min(characterCount, capacity, 2000);
+    const characters = [];
+    for (let i = 0; i < count; i += 1) {
+        const entry = characterInfo.add(ARRAY_DATA + i * offsets.characterInfoStride);
+        characters.push({
+            i,
+            ch: String.fromCharCode(entry.add(charInfo.character).readU16()),
+            index: entry.add(charInfo.index).readS32(),
+            line: entry.add(charInfo.lineNumber).readS32(),
+            visible: entry.add(charInfo.isVisible).readU8() !== 0,
+            origin: entry.add(charInfo.origin).readFloat(),
+            xAdvance: entry.add(charInfo.xAdvance).readFloat(),
+            bl: readVector3(entry, charInfo.bottomLeft),
+            tr: readVector3(entry, charInfo.topRight),
+            ascender: entry.add(charInfo.ascender).readFloat(),
+            descender: entry.add(charInfo.descender).readFloat(),
+            scale: entry.add(charInfo.scale).readFloat(),
+        });
+    }
+    const lines = [];
+    if (!lineInfo.isNull()) {
+        const lineCapacity = lineInfo.add(ARRAY_LENGTH).readS32();
+        for (let i = 0; i < Math.min(lineCount, lineCapacity, 64); i += 1) {
+            const entry = lineInfo.add(ARRAY_DATA + i * offsets.lineInfoStride);
+            lines.push({
+                i,
+                first: entry.add(lineInfoOffsets.firstCharacterIndex).readS32(),
+                last: entry.add(lineInfoOffsets.lastCharacterIndex).readS32(),
+                count: entry.add(lineInfoOffsets.characterCount).readS32(),
+                ascender: entry.add(lineInfoOffsets.ascender).readFloat(),
+                baseline: entry.add(lineInfoOffsets.baseline).readFloat(),
+                descender: entry.add(lineInfoOffsets.descender).readFloat(),
+            });
+        }
+    }
+    const text = characters.map((entry) => entry.ch).join('');
+    return {
+        characterCount,
+        lineCount,
+        text,
+        lines,
+        characters: sampleSize > 0 ? characters.slice(0, sampleSize).concat(characters.slice(-sampleSize)) : characters,
+    };
+}
+
+const user32 = {
+    getClientRect: new NativeFunction(Module.getGlobalExportByName('GetClientRect'), 'bool', ['pointer', 'pointer']),
+    getActiveWindow: new NativeFunction(Module.getGlobalExportByName('GetActiveWindow'), 'pointer', []),
+    enumWindows: new NativeFunction(Module.getGlobalExportByName('EnumWindows'), 'bool', ['pointer', 'pointer']),
+    getWindowThreadProcessId: new NativeFunction(
+        Module.getGlobalExportByName('GetWindowThreadProcessId'),
+        'uint32',
+        ['pointer', 'pointer'],
+    ),
+    isWindowVisible: new NativeFunction(Module.getGlobalExportByName('IsWindowVisible'), 'bool', ['pointer']),
+};
+
+// The game's own window is the only visible top-level window it owns.
+function findMainWindow() {
+    let best = NULL;
+    let bestArea = 0;
+    const pidSlot = Memory.alloc(4);
+    const rect = Memory.alloc(16);
+    const callback = new NativeCallback(
+        (hwnd) => {
+            user32.getWindowThreadProcessId(hwnd, pidSlot);
+            if (pidSlot.readU32() !== Process.id || !user32.isWindowVisible(hwnd)) return 1;
+            user32.getClientRect(hwnd, rect);
+            const area = rect.add(8).readS32() * rect.add(12).readS32();
+            if (area > bestArea) {
+                bestArea = area;
+                best = hwnd;
+            }
+            return 1;
+        },
+        'int',
+        ['pointer', 'pointer'],
+    );
+    user32.enumWindows(callback, NULL);
+    return best;
+}
+
+function clientSize() {
+    const window = findMainWindow();
+    if (window.isNull()) return null;
+    const rect = Memory.alloc(16);
+    user32.getClientRect(window, rect);
+    return { hwnd: window.toString(), width: rect.add(8).readS32(), height: rect.add(12).readS32() };
+}
+
+// --- live hooks --------------------------------------------------------------
+
+Interceptor.attach(mono.compile_method(method(UIAdv, 'ShowText', 3)), {
+    onEnter(args) {
+        advtextInstance = args[0].add(offsets.advtext).readPointer();
+        pendingLine = {
+            txin: readMonoString(args[1]),
+            dispnamein: readMonoString(args[2]),
+            updateonly: args[3].toInt32() & 0xff,
+        };
+        send({ type: 'ShowText', advtext: advtextInstance.toString(), line: pendingLine });
+    },
+});
+
+Interceptor.attach(mono.compile_method(method(UIAdv, 'EnsureTextFit', 1)), {
+    onEnter(args) {
+        send({ type: 'EnsureTextFit', tx: readMonoString(args[1]) });
+    },
+});
+
+Interceptor.attach(mono.compile_method(method(TextMeshProUGUI, 'GenerateTextMesh', 0)), {
+    onEnter(args) {
+        this.tmp = args[0];
+    },
+    onLeave() {
+        const tmp = this.tmp;
+        if (!advtextInstance || !tmp.equals(advtextInstance) || !pendingLine) return;
+        const layout = readLayout(tmp, DUMP === 'layout' ? 0 : 3);
+        if (!layout) return;
+        pendingLine = null;
+        const canvas = tmp.add(offsets.canvas).readPointer();
+        const transform = invokeObject(methods.componentTransform, tmp);
+        const camera = invokeObject(methods.canvasWorldCamera, canvas);
+        const matrix = invokeMatrix(methods.localToWorld, transform);
+        const screenHeight = invokeInt(methods.screenHeight, null);
+        let boxes = null;
+        if (camera && matrix) {
+            const screenTransform = deriveScreenTransform(camera, matrix);
+            boxes = { screenTransform, glyphs: [] };
+            const full = readLayout(tmp, 0);
+            // Cells come from the pen advance and the line's own ascender/descender, so
+            // every glyph on a line shares one vertical band and the cells tile the line.
+            for (const glyph of full.characters) {
+                const line = full.lines[glyph.line] || { ascender: glyph.ascender, descender: glyph.descender };
+                const topLeft = applyScreenTransform(screenTransform, glyph.origin, line.ascender);
+                const bottomRight = applyScreenTransform(screenTransform, glyph.xAdvance, line.descender);
+                boxes.glyphs.push({
+                    ch: glyph.ch,
+                    line: glyph.line,
+                    code: glyph.ch.charCodeAt(0),
+                    x: Math.round(topLeft[0]),
+                    y: Math.round(screenHeight - topLeft[1]),
+                    width: Math.round(bottomRight[0] - topLeft[0]),
+                    height: Math.round(topLeft[1] - bottomRight[1]),
+                });
+            }
+        }
+        send({
+            boxes,
+            type: 'layout',
+            currentText: readMonoString(tmp.add(offsets.text).readPointer()),
+            screen: { width: invokeInt(methods.screenWidth, null), height: invokeInt(methods.screenHeight, null) },
+            client: clientSize(),
+            canvas: describeCanvas(canvas),
+            localToWorld: invokeMatrix(methods.localToWorld, transform),
+            layout,
+        });
+    },
+});
+
+send({ type: 'ready', dump: DUMP, offsets, charInfo, lineInfoOffsets });

--- a/scripts/engine-hooks/probe-unity-mono.mjs
+++ b/scripts/engine-hooks/probe-unity-mono.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+// Discovery probe for the Unity/Mono + TextMeshPro engine hook.
+//
+// Resolves classes through the Mono runtime rather than byte signatures, hooks the
+// game's dialogue entry point, and dumps whatever the --dump option asks for.
+//
+// Usage: node scripts/engine-hooks/probe-unity-mono.mjs --pid=<pid> [--dump=canvas|layout|classes] [--timeout=20000]
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import frida from 'frida';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+function option(name, fallback = null) {
+    const prefix = `--${name}=`;
+    const match = process.argv.slice(2).find((argument) => argument.startsWith(prefix));
+    return match?.slice(prefix.length) ?? fallback;
+}
+
+const pid = Number.parseInt(option('pid') ?? '', 10);
+if (!Number.isInteger(pid) || pid <= 0) throw new Error('Pass --pid=<number>.');
+const dump = option('dump', 'canvas');
+const timeoutMs = Number.parseInt(option('timeout') ?? '20000', 10);
+
+const source = fs.readFileSync(path.join(scriptDirectory, 'probe-unity-mono.agent.js'), 'utf8');
+const session = await frida.attach(pid);
+const script = await session.createScript(`globalThis.__PROBE_DUMP__ = ${JSON.stringify(dump)};\n${source}`, {
+    name: 'probe-unity-mono',
+    runtime: 'qjs',
+});
+script.message.connect((message) => {
+    if (message.type === 'error') {
+        process.stderr.write(`${message.stack || message.description}\n`);
+        return;
+    }
+    process.stdout.write(`${JSON.stringify(message.payload, null, 2)}\n`);
+});
+await script.load();
+
+await new Promise((resolve) => setTimeout(resolve, timeoutMs));
+try {
+    if (!script.isDestroyed) await script.unload();
+} catch {}
+try {
+    if (!session.isDetached()) await session.detach();
+} catch {}


### PR DESCRIPTION
I was bored and had some spare usage so I thought I'd try this out. Don't know much about hooking personally so no idea how much of this can be reused for other Unity games. If this needs any changes just let me know and I'll throw Claude at it. 

edit: I already ran this after I fixed the node issues on my machine and it works well, edited out the part where it yapped about failing tests.

---

## Summary

Adds a built-in engine hook for the Steam releases of **Aokana**, **Aokana EXTRA1** and
**Aokana EXTRA2**. They are Unity/Mono games using TextMeshPro, so this also adds the
first Unity decoder to the catalog: `unity-tmp-v1`.

The hook captures the displayed dialogue line and exact per-character rectangles, and
implements the advance RPC. No Agent script, helper, message format or fallback is
involved.

**Shared-file footprint is one line** — the `unity-tmp-v1` entry in
`electron-src/main/engine_hooks/decoders/index.ts` (plus its id list in
`decoders/index.test.ts`). Everything else is new files.

## What's here

| Path | |
| --- | --- |
| `electron-src/assets/engine_hooks/aokana-steam/` | manifest, payload, NOTICE |
| `electron-src/main/engine_hooks/unity_tmp_decoder.ts` | pure decoder + tests |
| `electron-src/main/engine_hooks/decoders/unity-tmp.ts` | descriptor + tests |
| `scripts/engine-hooks/probe-unity-mono.{mjs,agent.js}` | discovery probe |
| `scripts/engine-hooks/dump-support-boxes.mjs` | dumps a package's full glyph set for visual checking |
| `docs/AOKANA_ENGINE_HOOK.md` | how each hook was established, with live evidence |

## Design notes worth reviewing

**No byte signatures.** A Mono game can be resolved through the runtime's own metadata:
`mono_class_from_name`, `mono_class_get_method_from_name` (name *and* parameter count,
which is what makes the match unique), `mono_field_get_offset`, `mono_compile_method`.
That is ASLR-safe by construction, survives a rebuild that moves code, needs no memory
scanning at all, and fails closed with a usable message when a name is absent:

```
Error: The class UIAdvNotHere is not in Assembly-CSharp.
Error: The method GenerateTextMeshNope/0 was not found.
```

This is a deliberate departure from how the existing decoders identify their target,
and it is why `unity-tmp-v1` does not require `target.moduleName` — see below.

**One package covers three games.** They share the same game code
(`UIAdv.ShowText(string, string, bool)`, the `advtext` field), but not much else — the
base game and EXTRA1 are Unity 2018.2.19f1, EXTRA2 is 2021.3.15f1. Because every offset
is read from the runtime at injection time, none of that has to be configured:

| | Aokana / EXTRA1 | EXTRA2 |
| --- | --- | --- |
| Mono runtime module | `mono.dll` | `mono-2.0-bdwgc.dll` |
| `mono_assembly_get_name` exported | no | yes |
| `TMP_CharacterInfo` array stride | 316 | 356 |
| `origin` / `xAdvance` offsets | 264 / 280 | 268 / 272 |
| `ascender` / `descender` offsets | 268 / 276 | 276 / 284 |
| `TMP_Text.m_textInfo` offset | 236 | 256 |

TextMeshPro even reorders fields between versions — `xAdvance` moves from after
`descender` to before it — so hard-coded offsets would silently produce garbage boxes.

Happy to split this into one package per title if you'd prefer that; it is three
manifests and three payload copies instead of one.

**No `target.moduleName`.** Unity renames the Mono runtime by version, so a package
spanning both cannot name one. The payload identifies the runtime by what it *is*
rather than what it is called: the single loaded module exporting
`mono_get_root_domain`. More than one match, or none, fails closed with the module
names listed.

**Text.** The raw script string is deliberately not used — it packs all four
localisations into one string separated by `U+0002`, plus rich-text markup, so
capturing it would mine English, Japanese and both Chinese variants at once. The
characters TextMeshPro actually laid out are read instead, so the mined text is already
markup-free and language-correct.

Capture point is `UIAdv.ShowText` to arm a line, then `TextMeshProUGUI.GenerateTextMesh`
on leave for the completed layout. Excluded: other TMP components (speaker name,
backlog, menus), the `EnsureTextFit` font-fitting passes, the pre-reveal clear, the
reveal's repeated redraws, and `ReapplyText` re-applications (reported as capture mode
`1`, dropped by `acceptedModes: [0]`).

**Geometry.** TMP cells are in the text component's local space. The payload resolves
them through the engine's own state — `Transform.localToWorldMatrix`, then
`Graphic.canvas` → `Canvas.worldCamera`, then three reference points through
`Camera.WorldToScreenPoint` to pin down the affine canvas→screen map (a UI canvas is a
plane, so three points describe it exactly, at three managed calls per line instead of
two per character), normalised by `Camera.pixelRect` and scaled to the in-process
`GetClientRect`.

`Canvas.scaleFactor` is observed but deliberately not applied as the transform — it is
already folded into the matrix, and applying it again would double-count it. No width
or height is stored in the manifest.

## Live validation

Every capture below came from the packaged artifact via
`scripts/engine-hooks/run-support.mjs`, not from a probe, and each was confirmed
visually by drawing the returned rectangles over a screenshot — cells land on their
glyphs and line bands cover exactly the rendered rows.

| Title | Client size | Result |
| --- | --- | --- |
| Aokana | 3627×2040 | 72 glyphs, 3 lines |
| Aokana | 1600×900 | 71 glyphs, 3 lines |
| Aokana EXTRA1 | 1280×720 | 31 glyphs, 1 line |
| Aokana EXTRA2 | 3648×2052 | 86 glyphs, 3 lines |
| Aokana EXTRA2 | 1600×900 | 62 glyphs, 2 lines |

Two client sizes per Unity version, because a single `GetClientRect` does not prove the
coordinate space. The canvas scale factor differs across the EXTRA2 pair (1.9 vs 0.833)
and the client-pixel results still line up, which is what shows the transform is
measured rather than assumed.

**One advance RPC is exactly one progression.** With `--lines=2`, a single advance
produced one `text-layout` and the runner then timed out waiting for a second:

```
{"type":"advance","delivery":"foreground-keyboard","activated":1,"foregroundAtDelivery":true}
  "text": "「そんなことあるよ」"
Error: No text layout arrived within 9000 ms.
```

Four advances produced exactly four layouts, sequential, with no duplicates and nothing
from the name or backlog components.

## Testing

- `npx vitest run electron-src/main/engine_hooks` — 73 passing, including 8 new decoder
  tests and 8 new manifest-validation tests. Decoder tests were written before the
  implementation.
- `npm run build:main` — clean.
- No Python touched, so Ruff and pytest are not applicable.

## Limitations

- Only the dialogue line is captured; the speaker name is a separate TMP component and
  is not mined.
- `TMP_CharacterInfo.character` is a single UTF-16 code unit. The payload rejoins a
  surrogate pair when TMP emits one, but a build that truncates an astral code point
  into one cell cannot be recovered. Japanese script is unaffected.
- Ruby/furigana is not handled; these titles do not use it.
- The package assumes exactly one Mono runtime is loaded, and refuses rather than
  guessing if that does not hold.
- The dialogue call is game code, so this package covers the Aokana titles that share
  it. Another Unity + TextMeshPro game reuses `unity-tmp-v1` and the payload by shipping
  its own package naming that game's dialogue class, method and text field.
 